### PR TITLE
pull policy IfNotPresent for csi-lvm-provisioner

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -14,11 +14,11 @@ images:
 - name: csi-lvm-controller
   sourceRepository: github.com/metal-stack/csi-lvm-controller
   repository: metalstack/csi-lvm-controller
-  tag: v0.4.0
+  tag: v0.4.1
 - name: csi-lvm-provisioner
   sourceRepository: github.com/metal-stack/csi-lvm-provisioner
   repository: metalstack/csi-lvm-provisioner
-  tag: v0.4.0
+  tag: v0.4.1
 # can be provided via image override:
 # - name: authn-webhook
 #   sourceRepository:

--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -108,6 +108,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: CSI_LVM_PULL_POLICY
+          value: "IfNotPresent"
         - name: CSI_LVM_PROVISIONER_IMAGE
           value: {{ index .Values.images "csi-lvm-provisioner" }}
         - name: CSI_LVM_DEVICE_PATTERN


### PR DESCRIPTION
- Since csi-lvm images are now tagged, there is no need for a pullAlways policy.
IfNotPresent speeds up the creation of PVC and therefore creation of pods which depends on PVCs.

- update csi-lvm versions to v0.4.1
