### PR TITLE
allow outgoing http alongside https

### DIFF
--- a/charts/internal/shoot-control-plane/templates/network-policies.yaml
+++ b/charts/internal/shoot-control-plane/templates/network-policies.yaml
@@ -52,6 +52,23 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
+  name: egress-allow-http
+  namespace: kube-system
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 80
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
   name: egress-allow-ntp
   namespace: kube-system
 spec:


### PR DESCRIPTION
because package managers tend to download packages with http only. The upcomming etcd-druid also installs wget.

see: https://github.com/gardener/etcd-druid/blob/master/charts/etcd/templates/configmap-etcd-bootstrap.yaml#L21


@rfranzke