### PR TITLE
Run tests in CI and add test-in-docker target.

### DIFF
--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -11,10 +11,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Lint
-      uses: actions-contrib/golangci-lint@master
-      with:
-        args: run --timeout 3m
+    - name: Check (lint) and Test
+      run: |
+        make test-in-docker
     - name: Build and push Docker image
       run: |
         docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,10 +11,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Lint
-      uses: actions-contrib/golangci-lint@master
-      with:
-        args: run --timeout 3m
+    - name: Check (lint) and Test
+      run: |
+        make test-in-docker
     - name: Build and push Docker image
       run: |
         docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
 name: Build image from release tag
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -11,10 +11,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Lint
-      uses: actions-contrib/golangci-lint@master
-      with:
-        args: run --timeout 3m
+    - name: Check (lint) and Test
+      run: |
+        make test-in-docker
     - name: Build and push Docker image
       run: |
         docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,7 @@
+run:
+  concurrency: 4
+  deadline: 10m
+
+linters:
+  disable:
+  - unused

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/golang/mock v1.4.4-0.20200731163441-8734ec565a4d
 	github.com/google/go-cmp v0.5.2
 	github.com/google/uuid v1.1.1
+	github.com/imdario/mergo v0.3.8
 	github.com/metal-stack/firewall-controller v0.1.8
 	github.com/metal-stack/metal-go v0.8.3
 	github.com/metal-stack/metal-lib v0.5.0

--- a/pkg/apis/metal/helper/helper.go
+++ b/pkg/apis/metal/helper/helper.go
@@ -15,8 +15,9 @@
 package helper
 
 import (
-	"encoding/json"
 	"fmt"
+
+	"github.com/imdario/mergo"
 
 	"github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/metal"
 )
@@ -50,14 +51,11 @@ func MergeIAMConfig(into *metal.IAMConfig, from *metal.IAMConfig) (*metal.IAMCon
 	}
 
 	merged := *into
-	tmp, err := json.Marshal(from)
+	err := mergo.Merge(&merged, from, mergo.WithOverride)
 	if err != nil {
 		return nil, err
 	}
-	err = json.Unmarshal(tmp, &merged)
-	if err != nil {
-		return nil, err
-	}
+
 	return &merged, nil
 }
 

--- a/pkg/apis/metal/helper/helper_test.go
+++ b/pkg/apis/metal/helper/helper_test.go
@@ -80,11 +80,11 @@ func TestMergeIAMConfig(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			want, err := MergeIAMConfig(tt.args.into, tt.args.from)
+			got, err := MergeIAMConfig(tt.args.into, tt.args.from)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("MergeIAMConfig() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if diff := cmp.Diff(want, tt.want); diff != "" {
+			if diff := cmp.Diff(tt.want, got); diff != "" {
 				t.Errorf("MergeIAMConfig() mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
Closes #36.

Uses linting from Gardener `check.sh`. Runs wrapped into Docker container which can be executed easily on local machines as well without installing anything wild.

Fixes a broken test as well by using another dependency for merging structs ("mergo").