### PR TITLE
Add pool labels to machine tags.

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -253,24 +253,30 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 			kubernetesTopologyZoneTag   = fmt.Sprintf("topology.kubernetes.io/zone=%s", infrastructureConfig.PartitionID)
 		)
 
+		tags := []string{
+			kubernetesClusterTag,
+			kubernetesRoleTag,
+			kubernetesInstanceTypeTag,
+			kubernetesTopologyRegionTag,
+			kubernetesTopologyZoneTag,
+
+			metalClusterIDTag,
+			metalClusterNameTag,
+			metalClusterProjectTag,
+		}
+
+		for k, v := range pool.Labels {
+			tags = append(tags, fmt.Sprintf("%s=%s", k, v))
+		}
+
 		machineClassSpec := map[string]interface{}{
 			"partition": infrastructureConfig.PartitionID,
 			"size":      pool.MachineType,
 			"project":   projectID,
 			"network":   privateNetwork.ID,
 			"image":     machineImage,
-			"tags": []string{
-				kubernetesClusterTag,
-				kubernetesRoleTag,
-				kubernetesInstanceTypeTag,
-				kubernetesTopologyRegionTag,
-				kubernetesTopologyZoneTag,
-
-				metalClusterIDTag,
-				metalClusterNameTag,
-				metalClusterProjectTag,
-			},
-			"sshkeys": []string{string(w.worker.Spec.SSHPublicKey)},
+			"tags":      tags,
+			"sshkeys":   []string{string(w.worker.Spec.SSHPublicKey)},
 			"secret": map[string]interface{}{
 				"cloudConfig": string(pool.UserData),
 			},


### PR DESCRIPTION
Adds tags to machines like:

```
    pools:                                                                                                                                                                                                                                                                      
    - labels:                                                                                                                                                                                                                                                                   
        node.kubernetes.io/role: node                                                                                                                                                                                                                                           
        worker.garden.sapcloud.io/group: default-worker                                                                                                                                                                                                                         
        worker.gardener.cloud/cri-name: containerd                                                                                                                                                                                                                              
        worker.gardener.cloud/pool: default-worker                                                                                                                                                                                                                              
        worker.gardener.cloud/system-components: "true"  
```

Will be useful when we have multiple worker pools more regularly.