### PR TITLE
Ignore gardener managed API servers (APIServerSNI)

### DIFF
--- a/pkg/webhook/controlplaneexposure/ensurer.go
+++ b/pkg/webhook/controlplaneexposure/ensurer.go
@@ -15,6 +15,7 @@ import (
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -47,6 +48,11 @@ func (e *ensurer) EnsureKubeAPIServerService(ctx context.Context, ectx genericmu
 
 // EnsureKubeAPIServerDeployment ensures that the kube-apiserver deployment conforms to the provider requirements.
 func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, ectx genericmutator.EnsurerContext, new, old *appsv1.Deployment) error {
+	// ignore gardener managed (APIServerSNI-enabled) apiservers.
+	if v1beta1helper.IsAPIServerExposureManaged(new) {
+		return nil
+	}
+
 	// Get load balancer address of the kube-apiserver service
 	address, err := kutil.GetLoadBalancerIngress(ctx, e.client, new.Namespace, v1beta1constants.DeploymentNameKubeAPIServer)
 	if err != nil {


### PR DESCRIPTION
When `APIServerSNI` feature gate is enabled, there is no need to set any kube-apiserver flags as those are managed by Gardener.

For example [aws-provider](https://github.com/gardener/gardener-extension-provider-aws/blob/d8b41a8b6b28a266d818060d50f9140a11d4305d/pkg/webhook/controlplaneexposure/ensurer.go#L68-L76).
