### PR TITLE
Push to ghcr.io and don't push image on forked PRs.

### DIFF
--- a/.github/workflows/latest.yaml
+++ b/.github/workflows/latest.yaml
@@ -11,14 +11,23 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Docker Login
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ secrets.DOCKER_REGISTRY }}
+        username: ${{ secrets.DOCKER_REGISTRY_USER }}
+        password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
     - name: Check (lint) and Test
       run: |
         make test-in-docker
+
     - name: Build and push Docker image
       run: |
-        docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_TOKEN }}
         make docker-image
         make docker-push
+
     - uses: release-drafter/release-drafter@v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -11,12 +11,22 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Docker Login
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ secrets.DOCKER_REGISTRY }}
+        username: ${{ secrets.DOCKER_REGISTRY_USER }}
+        password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+      if: github.repository_owner == 'metal-stack'
+
     - name: Check (lint) and Test
       run: |
         make test-in-docker
+
     - name: Build and push Docker image
       run: |
-        docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_TOKEN }}
         export GITHUB_TAG_NAME=${GITHUB_HEAD_REF##*/}
         make docker-image
         make docker-push
+      if: github.repository_owner == 'metal-stack'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,12 +11,20 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+
+    - name: Docker Login
+      uses: docker/login-action@v1
+      with:
+        registry: ${{ secrets.DOCKER_REGISTRY }}
+        username: ${{ secrets.DOCKER_REGISTRY_USER }}
+        password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
     - name: Check (lint) and Test
       run: |
         make test-in-docker
+
     - name: Build and push Docker image
       run: |
-        docker login -u ${{ secrets.DOCKER_HUB_USER }} -p ${{ secrets.DOCKER_HUB_TOKEN }}
         export GITHUB_TAG_NAME=${GITHUB_REF##*/}
         make docker-image
         make docker-push

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_TAG                   := $(or ${GITHUB_TAG_NAME}, latest)
-REGISTRY                    := metalstack
+REGISTRY                    := ghcr.io/metal-stack
 IMAGE_PREFIX                := $(REGISTRY)
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 HACK_DIR                    := $(REPO_ROOT)/hack


### PR DESCRIPTION
Should bring:

- Brings Docker rate limit mitigation
- Successful pipelines for external contributors