### PR TITLE
More resilient firewall recreation.

### DIFF
--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -162,12 +162,12 @@ func reconcileFirewall(ctx context.Context, r *firewallReconciler) error {
 		r.logger.Info("firewall created", "cluster-id", r.clusterID, "cluster", r.cluster.Shoot.Name, "machine-id", r.providerStatus.Firewall.MachineID)
 		return nil
 	case firewallActionDeleteAndRecreate:
-		err := deleteFirewallFromStatus(ctx, r)
+		r.logger.Info("firewall removed from status", "cluster-id", r.clusterID, "cluster", r.cluster.Shoot.Name, "machine-id", r.machineID)
+		err := deleteFirewall(r.logger, r.machineID, r.infrastructureConfig.ProjectID, r.clusterTag, r.mclient)
 		if err != nil {
 			return err
 		}
-		r.logger.Info("firewall removed from status", "cluster-id", r.clusterID, "cluster", r.cluster.Shoot.Name, "machine-id", r.machineID)
-		err = deleteFirewall(r.logger, r.machineID, r.infrastructureConfig.ProjectID, r.clusterTag, r.mclient)
+		err = deleteFirewallFromStatus(ctx, r)
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/infrastructure/actuator_reconcile.go
+++ b/pkg/controller/infrastructure/actuator_reconcile.go
@@ -162,16 +162,16 @@ func reconcileFirewall(ctx context.Context, r *firewallReconciler) error {
 		r.logger.Info("firewall created", "cluster-id", r.clusterID, "cluster", r.cluster.Shoot.Name, "machine-id", r.providerStatus.Firewall.MachineID)
 		return nil
 	case firewallActionDeleteAndRecreate:
-		r.logger.Info("firewall removed from status", "cluster-id", r.clusterID, "cluster", r.cluster.Shoot.Name, "machine-id", r.machineID)
 		err := deleteFirewall(r.logger, r.machineID, r.infrastructureConfig.ProjectID, r.clusterTag, r.mclient)
 		if err != nil {
 			return err
 		}
+		r.logger.Info("firewall deleted", "cluster-id", r.clusterID, "cluster", r.cluster.Shoot.Name, "machine-id", r.machineID)
 		err = deleteFirewallFromStatus(ctx, r)
 		if err != nil {
 			return err
 		}
-		r.logger.Info("firewall deleted", "cluster-id", r.clusterID, "cluster", r.cluster.Shoot.Name, "machine-id", r.machineID)
+		r.logger.Info("firewall removed from status", "cluster-id", r.clusterID, "cluster", r.cluster.Shoot.Name, "machine-id", r.machineID)
 		err = createFirewall(ctx, r)
 		if err != nil {
 			return err


### PR DESCRIPTION
By switching around the current order of tasks

1. Delete firewall from status
1. Delete firewall at metal-api

on firewall recreation, we can possibly gain a more stable firewall reconciliation.

This should help the following scenarios: 

- https://github.com/metal-stack/gardener-extension-provider-metal/issues/119 when being caused by https://github.com/metal-stack/metal-api/pull/129