### PR TITLE
configure imagePullPolicy through providerConfig

### DIFF
--- a/charts/internal/control-plane/templates/accounting-exporter.yaml
+++ b/charts/internal/control-plane/templates/accounting-exporter.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
       - image: {{ index .Values.images "accounting-exporter" }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         name: accounting-exporter
         livenessProbe:
           httpGet:

--- a/charts/internal/control-plane/templates/authn-webhook-deployment.yaml
+++ b/charts/internal/control-plane/templates/authn-webhook-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       containers:
       - name: kubernetes-authn-webhook
         image: {{ index .Values.images "authn-webhook" }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         ports:
         - containerPort: {{ .Values.authnWebhook.port }}
           protocol: TCP

--- a/charts/internal/control-plane/templates/cloud-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/cloud-controller-manager.yaml
@@ -54,7 +54,7 @@ spec:
       containers:
       - name: cloud-controller-manager
         image: {{ index .Values.images "metalccm" }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         command:
         - ./metal-cloud-controller-manager
         - --cloud-provider=metal

--- a/charts/internal/control-plane/templates/group-rolebinding-controller.yaml
+++ b/charts/internal/control-plane/templates/group-rolebinding-controller.yaml
@@ -24,7 +24,7 @@ spec:
       containers:
       - name: group-rolebinding-controller
         image: {{ index .Values.images "group-rolebinding-controller" }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         command: ["/group-rolebinding-controller"]
         args:
         - --excludeNamespaces=kube-system,kube-public,kube-node-lease,default

--- a/charts/internal/control-plane/templates/splunk-auditlog-webhook-deployment.yaml
+++ b/charts/internal/control-plane/templates/splunk-auditlog-webhook-deployment.yaml
@@ -25,7 +25,7 @@ spec:
       containers:
       - name: splunk-audit-webhook
         image: {{ index .Values.images "splunk-audit-webhook" }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         env:
         - name: SPLUNK_AUDIT_WEBHOOK_SERVER_URLS
           value: {{ .Values.splunkAuditWebhook.hecEndpoint.url }}

--- a/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       containers:
       - name: machine-controller-manager-provider-metal
         image: {{ index .Values.images "machine-controller-manager-provider-metal" }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         command:
         - ./machine-controller
         - --control-kubeconfig=inClusterConfig
@@ -74,7 +74,7 @@ spec:
           readOnly: true
       - name: machine-controller-manager
         image: {{ index .Values.images "machine-controller-manager" }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         command:
         - ./machine-controller-manager
         - --control-kubeconfig=inClusterConfig

--- a/charts/internal/machine-controller-manager/seed/templates/legacy/deployment.yaml
+++ b/charts/internal/machine-controller-manager/seed/templates/legacy/deployment.yaml
@@ -39,7 +39,7 @@ spec:
       containers:
       - name: metal-machine-controller-manager
         image: registry.fi-ts.io/gardener/machine-controller-manager:metal
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         command:
         - ./machine-controller-manager
         - --control-kubeconfig=inClusterConfig

--- a/charts/internal/shoot-control-plane/templates/firewall/droptailer.yaml
+++ b/charts/internal/shoot-control-plane/templates/firewall/droptailer.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
       - image: {{ index .Values.images "droptailer" }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         name: droptailer
         ports:
         - protocol: TCP

--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -213,7 +213,7 @@ spec:
             fieldRef:
               fieldPath: status.hostIP
         image: {{ index .Values.images "metallb-speaker" }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         name: speaker
         ports:
         - containerPort: 7472
@@ -269,7 +269,7 @@ spec:
         - --port=7472
         - --config=config
         image: {{ index .Values.images "metallb-controller" }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         name: controller
         ports:
         - containerPort: 7472

--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -27,33 +27,33 @@ metadata:
 rules:
 - apiGroups:
   - ""
-  resources: 
+  resources:
   - nodes
   - persistentvolumeclaims
-  verbs: 
+  verbs:
   - get
   - list
   - watch
-- apiGroups: 
+- apiGroups:
   - ""
-  resources: 
+  resources:
   - endpoints
   - persistentvolumes
   - pods
-  verbs: 
+  verbs:
   - "*"
-- apiGroups: 
+- apiGroups:
   - ""
-  resources: 
+  resources:
   - events
-  verbs: 
+  verbs:
   - create
   - patch
 - apiGroups:
   - storage.k8s.io
-  resources: 
+  resources:
   - storageclasses
-  verbs: 
+  verbs:
   - get
   - list
   - watch
@@ -98,7 +98,7 @@ spec:
       containers:
       - name: csi-lvm-controller
         image: {{ index .Values.images "csi-lvm-controller" }}
-        imagePullPolicy: Always
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         command:
         - /csi-lvm-controller
         args:
@@ -221,7 +221,7 @@ spec:
       containers:
       - name: csi-lvm-reviver
         image: {{ index .Values.images "csi-lvm-provisioner" }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.config.global.imagePullPolicy }}
         securityContext:
           privileged: true
         env:

--- a/charts/provider-metal/values.yaml
+++ b/charts/provider-metal/values.yaml
@@ -69,6 +69,8 @@ config:
     enabled: false
     hecURL:
     hecToken:
+  global:
+    imagePullPolicy: IfNotPresent
 
 gardener:
   seed:


### PR DESCRIPTION
adds a config option

```yaml
  global:
    imagePullPolicy: 
```
to providerConfig

gepm will use this option for Deployments, so that we can have e.g. `Always` in the test control-plane and `IfNotPresent` in prod