### PR TITLE
enable TTL mechanism for finished jobs at api server

### DIFF
--- a/example/10-fake-shoot-controlplane.yaml
+++ b/example/10-fake-shoot-controlplane.yaml
@@ -148,6 +148,7 @@ spec:
         - --tls-cert-file=/srv/kubernetes/apiserver/kube-apiserver.crt
         - --tls-private-key-file=/srv/kubernetes/apiserver/kube-apiserver.key
         - --v=2
+        - --feature-gates=TTLAfterFinished=true
         image: k8s.gcr.io/hyperkube:v1.12.6
         imagePullPolicy: IfNotPresent
         name: kube-apiserver


### PR DESCRIPTION
this alpha feature enable to clean jobs after a time when finish. 
https://kubernetes.io/docs/concepts/workloads/controllers/job/#clean-up-finished-jobs-automatically