### PR TITLE
set priorityClass critical for metallb-speaker

### DIFF
--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -240,7 +240,7 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
-{{ if semverCompare ">= 1.17" .Values.kubernetesVersion -}}
+{{- if semverCompare ">= 1.17" .Values.kubernetesVersion }}
       priorityClassName: system-node-critical
 {{- end }}
 ---

--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -243,6 +243,7 @@ spec:
 {{- if semverCompare ">= 1.17" .Values.kubernetesVersion -}}
       priorityClassName: system-node-critical
 {{- end -}}
+
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -240,7 +240,7 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
-{{- if semverCompare ">= 1.17" .Values.kubernetesVersion -}}
+{{ if semverCompare ">= 1.17" .Values.kubernetesVersion -}}
       priorityClassName: system-node-critical
 {{- end }}
 ---

--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -242,8 +242,7 @@ spec:
         key: node-role.kubernetes.io/master
 {{- if semverCompare ">= 1.17" .Values.kubernetesVersion -}}
       priorityClassName: system-node-critical
-{{- end -}}
-
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -240,6 +240,9 @@ spec:
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+{{- if semverCompare ">= 1.17" .Values.kubernetesVersion -}}
+      priorityClassName: system-node-critical
+{{- end -}}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/internal/shoot-control-plane/values.yaml
+++ b/charts/internal/shoot-control-plane/values.yaml
@@ -1,4 +1,6 @@
 ---
+kubernetesVersion: "1.16.0"
+
 images:
     droptailer: image-repository:image-tag
     metallb-speaker: image-repository:image-tag

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -601,7 +601,8 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(ctx context.Context, c
 	}
 
 	values := map[string]interface{}{
-		"firewallSpec": fwSpec,
+		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
+		"firewallSpec":      fwSpec,
 		"groupRolebindingController": map[string]interface{}{
 			"enabled": vp.controllerConfig.Auth.Enabled,
 		},


### PR DESCRIPTION
Since k8s 1.17 system-critical priorityClasses aren't restricted to kube-system namespace anymore.
=> set priorityClass of speaker-daemonset to critical to prevent speaker-pods from getting evicted