### PR TITLE
Implementing MEP-6: Clusters with private networks only / DMZ

### DIFF
--- a/pkg/apis/metal/types_controlplane.go
+++ b/pkg/apis/metal/types_controlplane.go
@@ -35,7 +35,8 @@ type CloudControllerManagerConfig struct {
 	// FeatureGates contains information about enabled feature gates.
 	FeatureGates map[string]bool
 	// DefaultExternalNetwork explicitly defines the network from which the CCM allocates IPs for services of type load balancer
-	// If not defined, it will use the first network with the default external network tag from the infrastructure firewall networks
+	// If not defined, it will use the last network with the default external network tag from the infrastructure firewall networks
+	// Networks that are not derived from a private super network overrule DMZ networks.
 	// +optional
 	DefaultExternalNetwork *string
 }

--- a/pkg/apis/metal/types_controlplane.go
+++ b/pkg/apis/metal/types_controlplane.go
@@ -36,7 +36,7 @@ type CloudControllerManagerConfig struct {
 	FeatureGates map[string]bool
 	// DefaultExternalNetwork explicitly defines the network from which the CCM allocates IPs for services of type load balancer
 	// If not defined, it will use the last network with the default external network tag from the infrastructure firewall networks
-	// Networks that are not derived from a private super network overrule DMZ networks.
+	// Networks not derived from a private super network have precedence.
 	// +optional
 	DefaultExternalNetwork *string
 }

--- a/pkg/apis/metal/v1alpha1/types_controlplane.go
+++ b/pkg/apis/metal/v1alpha1/types_controlplane.go
@@ -37,7 +37,7 @@ type CloudControllerManagerConfig struct {
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// DefaultExternalNetwork explicitly defines the network from which the CCM allocates IPs for services of type load balancer
 	// If not defined, it will use the last network with the default external network tag from the infrastructure firewall networks
-	// Networks that are not derived from a private super network overrule DMZ networks.
+	// Networks not derived from a private super network have precedence.
 	// +optional
 	DefaultExternalNetwork *string `json:"defaultExternalNetwork" optional:"true"`
 }

--- a/pkg/apis/metal/v1alpha1/types_controlplane.go
+++ b/pkg/apis/metal/v1alpha1/types_controlplane.go
@@ -36,7 +36,8 @@ type CloudControllerManagerConfig struct {
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// DefaultExternalNetwork explicitly defines the network from which the CCM allocates IPs for services of type load balancer
-	// If not defined, it will use the first network with the default external network tag from the infrastructure firewall networks
+	// If not defined, it will use the last network with the default external network tag from the infrastructure firewall networks
+	// Networks that are not derived from a private super network overrule DMZ networks.
 	// +optional
 	DefaultExternalNetwork *string `json:"defaultExternalNetwork" optional:"true"`
 }

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -888,6 +888,10 @@ func getCCMChartValues(
 			return nil, errors.Wrap(err, fmt.Sprintf("could not retrieve user-given default external network: %s", defaultExternalNetwork))
 		}
 
+		if resp.Network.Shared && resp.Network.Partitionid != infrastructureConfig.PartitionID {
+			return nil, fmt.Errorf("shared external network must be in same partition as shoot")
+		}
+
 		if resp.Network.Projectid != "" && resp.Network.Projectid != infrastructureConfig.ProjectID && !resp.Network.Shared {
 			return nil, fmt.Errorf("cannot define default external unshared network of another project")
 		}


### PR DESCRIPTION
This PR allows to use private shared networks with the default-external label as external-network for the metal-ccm.
If there are multiple networks with the label the private networks have the lowest precedence.