### PR TITLE
#162 Metal-API access for authn-webhook

### DIFF
--- a/charts/internal/control-plane/templates/authn-webhook-deployment.yaml
+++ b/charts/internal/control-plane/templates/authn-webhook-deployment.yaml
@@ -57,6 +57,26 @@ spec:
           value: {{ .Values.authnWebhook.clusterName }}
         - name: DEBUG
           value: {{ quote .Values.authnWebhook.debug }}
+        - name: METAL_URL
+          valueFrom:
+            secretKeyRef:
+              name: kube-jwt-authn-webhook-metalapi-secret
+              key: metalapi-url
+        - name: METAL_HMAC
+          valueFrom:
+            secretKeyRef:
+              name: kube-jwt-authn-webhook-metalapi-secret
+              key: metalapi-hmac
+        - name: METAL_HMACAUTHTYPE
+          valueFrom:
+            secretKeyRef:
+              name: kube-jwt-authn-webhook-metalapi-secret
+              key: metalapi-authtype
+        - name: METAL_APITOKEN
+          valueFrom:
+            secretKeyRef:
+              name: kube-jwt-authn-webhook-metalapi-secret
+              key: metalapi-apitoken
         volumeMounts:
         - name: webhook-certs
           mountPath: /etc/webhook/certs
@@ -66,6 +86,18 @@ spec:
         secret:
             secretName: kube-jwt-authn-webhook-server
       restartPolicy: Always
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kube-jwt-authn-webhook-metalapi-secret
+  namespace: {{ .Release.Namespace }}
+data:
+  metalapi-url: {{ required ".Values.authnWebhook.metalapi.url is required" (b64enc .Values.authnWebhook.metalapi.url) }}
+  metalapi-hmac: {{ required ".Values.authnWebhook.metalapi.hmac is required" (b64enc .Values.authnWebhook.metalapi.hmac) }}
+  metalapi-authtype: {{ required ".Values.authnWebhook.metalapi.hmac_auth_type is required" (b64enc .Values.authnWebhook.metalapi.hmac_auth_type) }}
+  metalapi-apitoken: {{ required ".Values.authnWebhook.metalapi.apitoken is required" (b64enc .Values.authnWebhook.metalapi.apitoken) }}
 
 ---
 apiVersion: v1

--- a/charts/internal/control-plane/values.yaml
+++ b/charts/internal/control-plane/values.yaml
@@ -34,6 +34,12 @@ groupRolebindingController:
   clusterName: cluster-name
 
 authnWebhook:
+  metalapi:
+    url: https://metal-api
+    hmac: ABC123
+    hmac_auth_type: Metal-View
+    apitoken: ey123
+
   enabled: false
   port: 443
   debug: true

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -493,7 +493,18 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 		return nil, err
 	}
 
-	authValues, err := getAuthNGroupRoleChartValues(cpConfig, cluster, vp.controllerConfig.Auth)
+	metalEndpoint := metalControlPlane.Endpoint
+	metalCredentials, err := metalclient.ReadCredentialsFromSecretRef(ctx, vp.client, &cp.Spec.SecretRef)
+	if err != nil {
+		return nil, err
+	}
+	ma := metalAccess{
+		url:          metalEndpoint,
+		hmac:         metalCredentials.MetalAPIHMac,
+		hmacAuthType: "", // currently default is used
+		apiToken:     metalCredentials.MetalAPIKey,
+	}
+	authValues, err := getAuthNGroupRoleChartValues(cpConfig, cluster, vp.controllerConfig.Auth, ma)
 	if err != nil {
 		return nil, err
 	}
@@ -1060,8 +1071,15 @@ func getCCMChartValues(
 	return values, nil
 }
 
+type metalAccess struct {
+	url          string
+	hmac         string
+	hmacAuthType string
+	apiToken     string
+}
+
 // returns values for "authn-webhook" and "group-rolebinding-controller" that are thematically related
-func getAuthNGroupRoleChartValues(cpConfig *apismetal.ControlPlaneConfig, cluster *extensionscontroller.Cluster, config config.Auth) (map[string]interface{}, error) {
+func getAuthNGroupRoleChartValues(cpConfig *apismetal.ControlPlaneConfig, cluster *extensionscontroller.Cluster, config config.Auth, metalAccess metalAccess) (map[string]interface{}, error) {
 
 	annotations := cluster.Shoot.GetAnnotations()
 	clusterName := annotations[tag.ClusterName]
@@ -1078,6 +1096,12 @@ func getAuthNGroupRoleChartValues(cpConfig *apismetal.ControlPlaneConfig, cluste
 			"oidc": map[string]interface{}{
 				"issuerUrl":      ti.Url,
 				"issuerClientId": ti.ClientId,
+			},
+			"metalapi": map[string]interface{}{
+				"url":            metalAccess.url,
+				"hmac":           metalAccess.hmac,
+				"hmac_auth_type": metalAccess.hmacAuthType,
+				"apitoken":       metalAccess.apiToken,
 			},
 		},
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -463,7 +463,12 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 		return nil, err
 	}
 
-	mclient, err := metalclient.NewClient(ctx, vp.client, metalControlPlane.Endpoint, &cp.Spec.SecretRef)
+	metalCredentials, err := metalclient.ReadCredentialsFromSecretRef(ctx, vp.client, &cp.Spec.SecretRef)
+	if err != nil {
+		return nil, err
+	}
+
+	mclient, err := metalclient.NewClientFromCredentials(metalControlPlane.Endpoint, metalCredentials)
 	if err != nil {
 		return nil, err
 	}
@@ -494,10 +499,6 @@ func (vp *valuesProvider) GetControlPlaneChartValues(
 	}
 
 	metalEndpoint := metalControlPlane.Endpoint
-	metalCredentials, err := metalclient.ReadCredentialsFromSecretRef(ctx, vp.client, &cp.Spec.SecretRef)
-	if err != nil {
-		return nil, err
-	}
 	ma := metalAccess{
 		url:          metalEndpoint,
 		hmac:         metalCredentials.MetalAPIHMac,


### PR DESCRIPTION
Implements #162 

Metal-API access for authn-webhook with the currrently available metal HMAC.