### PR TITLE
add additional networks to ccm running config

### DIFF
--- a/charts/internal/control-plane/templates/cloud-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/cloud-controller-manager.yaml
@@ -92,6 +92,8 @@ spec:
             value: {{ .Values.cloudControllerManager.clusterID }}
           - name: METAL_DEFAULT_EXTERNAL_NETWORK_ID
             value: {{ .Values.cloudControllerManager.defaultExternalNetwork }}
+          - name: METAL_ADDITIONAL_NETWORKS
+            value: {{ .Values.cloudControllerManager.additionalNetworks }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/charts/internal/control-plane/values.yaml
+++ b/charts/internal/control-plane/values.yaml
@@ -19,6 +19,7 @@ cloudControllerManager:
   networkID: network-id
   clusterID: cluster-id
   defaultExternalNetwork: external-network-id
+  additionalNetworks: internet,mpls
   metal:
     endpoint: api-url
   resources:

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -1104,6 +1104,7 @@ func getCCMChartValues(
 			"networkID":              *privateNetwork.ID,
 			"podNetwork":             extensionscontroller.GetPodNetwork(cluster),
 			"defaultExternalNetwork": defaultExternalNetwork,
+			"additionalNetworks":     strings.Join(infrastructureConfig.Firewall.Networks, ","),
 			"metal": map[string]interface{}{
 				"endpoint": mcp.Endpoint,
 			},


### PR DESCRIPTION
Pass list of additionalNetworks to metal-ccm to speed up metallb reconciliation and saveone expensive networkList call there