### PR TITLE
Scale down ControlPlane components on hibernation

### DIFF
--- a/charts/internal/control-plane/templates/accounting-exporter.yaml
+++ b/charts/internal/control-plane/templates/accounting-exporter.yaml
@@ -34,6 +34,7 @@ metadata:
   labels:
     k8s-app: accounting-exporter
 spec:
+  replicas: {{ .Values.accountingExporter.replicas }}
   selector:
     matchLabels:
       k8s-app: accounting-exporter

--- a/charts/internal/control-plane/templates/authn-webhook-deployment.yaml
+++ b/charts/internal/control-plane/templates/authn-webhook-deployment.yaml
@@ -21,7 +21,7 @@ metadata:
   labels:
     k8s-app: kube-jwt-authn-webhook
 spec:
-  replicas: 1
+  replicas: {{ .Values.authnWebhook.replicas }}
   selector:
     matchLabels:
       k8s-app: kube-jwt-authn-webhook

--- a/charts/internal/control-plane/templates/duros-controller.yaml
+++ b/charts/internal/control-plane/templates/duros-controller.yaml
@@ -81,7 +81,7 @@ spec:
   selector:
     matchLabels:
       app: duros-controller
-  replicas: 1
+  replicas: {{ .Values.duros.replicas }}
   template:
     metadata:
       labels:

--- a/charts/internal/control-plane/templates/group-rolebinding-controller.yaml
+++ b/charts/internal/control-plane/templates/group-rolebinding-controller.yaml
@@ -21,7 +21,7 @@ metadata:
   name: group-rolebinding-controller
   namespace: {{ .Release.Namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.groupRolebindingController.replicas }}
   selector:
     matchLabels:
       app: group-rolebinding-controller

--- a/charts/internal/control-plane/values.yaml
+++ b/charts/internal/control-plane/values.yaml
@@ -31,9 +31,11 @@ cloudControllerManager:
 
 groupRolebindingController:
   enabled: false
+  replicas: 1
   clusterName: cluster-name
 
 authnWebhook:
+  replicas: 1
   metalapi:
     url: https://metal-api
     hmac: ABC123
@@ -55,6 +57,7 @@ limitValidatingWebhook:
 
 accountingExporter:
   enabled: false
+  replicas: 1
   enrichments:
     projectID: project-id
     projectName: project-name
@@ -82,6 +85,7 @@ accountingExporter:
 
 duros:
   enabled: false
+  replicas: 1
   storageClasses: []
   projectID: project-id
   controller:

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/gardener/gardener/extensions/pkg/util"
@@ -11,8 +12,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"path/filepath"
-
 	gardenerkubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
 	durosv1 "github.com/metal-stack/duros-controller/api/v1"
 	firewallv1 "github.com/metal-stack/firewall-controller/api/v1"
@@ -20,16 +19,17 @@ import (
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
 	"github.com/gardener/gardener/pkg/utils"
+
 	"github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/config"
 	apismetal "github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/metal"
 	"github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/metal/helper"
 
-	metalclient "github.com/metal-stack/gardener-extension-provider-metal/pkg/metal/client"
 	metalgo "github.com/metal-stack/metal-go"
+
+	metalclient "github.com/metal-stack/gardener-extension-provider-metal/pkg/metal/client"
 
 	"github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/metal/validation"
 
-	"github.com/metal-stack/gardener-extension-provider-metal/pkg/metal"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -37,6 +37,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/metal-stack/gardener-extension-provider-metal/pkg/metal"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -424,8 +426,9 @@ func (vp *valuesProvider) getAuthNConfigValues(ctx context.Context, cp *extensio
 
 	values := map[string]interface{}{
 		"authnWebhook": map[string]interface{}{
-			"url":     url,
-			"enabled": vp.controllerConfig.Auth.Enabled,
+			"replicas": extensionscontroller.GetReplicas(cluster, 1),
+			"url":      url,
+			"enabled":  vp.controllerConfig.Auth.Enabled,
 		},
 	}
 
@@ -1158,6 +1161,7 @@ func getAuthNGroupRoleChartValues(cpConfig *apismetal.ControlPlaneConfig, cluste
 
 		"groupRolebindingController": map[string]interface{}{
 			"enabled":     config.Enabled,
+			"replicas":    extensionscontroller.GetReplicas(cluster, 1),
 			"clusterName": clusterName,
 		},
 	}
@@ -1210,7 +1214,8 @@ func getAccountingExporterChartValues(ctx context.Context, client client.Client,
 
 	values := map[string]interface{}{
 		"accountingExporter": map[string]interface{}{
-			"enabled": accountingConfig.Enabled,
+			"enabled":  accountingConfig.Enabled,
+			"replicas": extensionscontroller.GetReplicas(cluster, 1),
 			"networkTraffic": map[string]interface{}{
 				"enabled": accountingConfig.NetworkTraffic.Enabled,
 			},
@@ -1238,7 +1243,8 @@ func getAccountingExporterChartValues(ctx context.Context, client client.Client,
 func getStorageControlPlaneChartValues(ctx context.Context, client client.Client, logger logr.Logger, storageConfig config.StorageConfiguration, cluster *extensionscontroller.Cluster, infrastructure *apismetal.InfrastructureConfig, nws networkMap) (map[string]interface{}, error) {
 	disabledValues := map[string]interface{}{
 		"duros": map[string]interface{}{
-			"enabled": false,
+			"enabled":  false,
+			"replicas": extensionscontroller.GetReplicas(cluster, 1),
 		},
 	}
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -426,9 +426,8 @@ func (vp *valuesProvider) getAuthNConfigValues(ctx context.Context, cp *extensio
 
 	values := map[string]interface{}{
 		"authnWebhook": map[string]interface{}{
-			"replicas": extensionscontroller.GetReplicas(cluster, 1),
-			"url":      url,
-			"enabled":  vp.controllerConfig.Auth.Enabled,
+			"url":     url,
+			"enabled": vp.controllerConfig.Auth.Enabled,
 		},
 	}
 
@@ -1144,6 +1143,7 @@ func getAuthNGroupRoleChartValues(cpConfig *apismetal.ControlPlaneConfig, cluste
 	values := map[string]interface{}{
 		"authnWebhook": map[string]interface{}{
 			"enabled":        config.Enabled,
+			"replicas":       extensionscontroller.GetReplicas(cluster, 1),
 			"tenant":         p.TenantID,
 			"providerTenant": config.ProviderTenant,
 			"clusterName":    clusterName,
@@ -1243,8 +1243,7 @@ func getAccountingExporterChartValues(ctx context.Context, client client.Client,
 func getStorageControlPlaneChartValues(ctx context.Context, client client.Client, logger logr.Logger, storageConfig config.StorageConfiguration, cluster *extensionscontroller.Cluster, infrastructure *apismetal.InfrastructureConfig, nws networkMap) (map[string]interface{}, error) {
 	disabledValues := map[string]interface{}{
 		"duros": map[string]interface{}{
-			"enabled":  false,
-			"replicas": extensionscontroller.GetReplicas(cluster, 1),
+			"enabled": false,
 		},
 	}
 
@@ -1338,6 +1337,7 @@ func getStorageControlPlaneChartValues(ctx context.Context, client client.Client
 	values := map[string]interface{}{
 		"duros": map[string]interface{}{
 			"enabled":        storageConfig.Duros.Enabled,
+			"replicas":       extensionscontroller.GetReplicas(cluster, 1),
 			"storageClasses": scs,
 			"projectID":      infrastructure.ProjectID,
 			"controller":     controllerValues,


### PR DESCRIPTION
Enhance the ControlPlane controller to use `extensionscontroller.GetReplicas` which checks if the shoot cluster is hibernated via the `Cluster` resource. If it is hibernated, provider-specific control plane components are scaled down (`replicas=0`).