### PR TITLE
DNS Based egress policies

### DIFF
--- a/charts/internal/crds-firewall/templates/metal-stack.io_clusterwidenetworkpolicies.yaml
+++ b/charts/internal/crds-firewall/templates/metal-stack.io_clusterwidenetworkpolicies.yaml
@@ -1,10 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: clusterwidenetworkpolicies.metal-stack.io
 spec:
@@ -41,7 +40,7 @@ spec:
             properties:
               description:
                 description: Description is a free form string, it can be used by
-                  the creator of the rule to store human readable explanation of the
+                  the creator of the rule to store human-readable explanation of the
                   purpose of this rule. Rules cannot be identified by comment.
                 type: string
               egress:
@@ -70,9 +69,7 @@ spec:
                               the policy. This field cannot be defined if the port
                               field is not defined or if the port field is defined
                               as a named (string) port. The endPort must be equal
-                              or greater than port. This feature is in Beta state
-                              and is enabled by default. It can be disabled using
-                              the Feature Gate "NetworkPolicyEndPort".
+                              or greater than port.
                             format: int32
                             type: integer
                           port:
@@ -100,7 +97,8 @@ spec:
                         this rule matches all destinations (traffic not restricted
                         by destination). If this field is present and contains at
                         least one item, this rule allows traffic only if the traffic
-                        matches at least one item in the to list.
+                        matches at least one item in the to list. To rules can't contain
+                        ToFQDNs rules.
                       items:
                         description: IPBlock describes a particular CIDR (Ex. "192.168.1.1/24","2001:db9::/64")
                           that is allowed to the pods matched by a NetworkPolicySpec's
@@ -121,6 +119,27 @@ spec:
                             type: array
                         required:
                         - cidr
+                        type: object
+                      type: array
+                    toFQDNs:
+                      description: List of FQDNs (fully qualified domain names) for
+                        outgoing traffic of a cluster for this rule. Items in this
+                        list are combined using a logical OR operation. This field
+                        is used as whitelist for DNS names. If none specified, no
+                        rule will be applied. ToFQDNs rules can't contain To rules.
+                      items:
+                        description: FQDNSelector describes rules for matching DNS
+                          names.
+                        properties:
+                          matchName:
+                            description: MatchName matches FQDN.
+                            pattern: ^([-a-zA-Z0-9_]+[.]?)+$
+                            type: string
+                          matchPattern:
+                            description: MatchPattern allows using "*" to match DNS
+                              names. "*" matches 0 or more valid characters.
+                            pattern: ^([-a-zA-Z0-9_*]+[.]?)+$
+                            type: string
                         type: object
                       type: array
                   type: object
@@ -183,9 +202,7 @@ spec:
                               the policy. This field cannot be defined if the port
                               field is not defined or if the port field is defined
                               as a named (string) port. The endPort must be equal
-                              or greater than port. This feature is in Beta state
-                              and is enabled by default. It can be disabled using
-                              the Feature Gate "NetworkPolicyEndPort".
+                              or greater than port.
                             format: int32
                             type: integer
                           port:
@@ -209,14 +226,35 @@ spec:
                   type: object
                 type: array
             type: object
+          status:
+            description: PolicyStatus defines the observed state for CWNP resource
+            properties:
+              fqdn_state:
+                additionalProperties:
+                  items:
+                    description: IPSet stores set name association to IP addresses
+                    properties:
+                      expirationTime:
+                        format: date-time
+                        type: string
+                      fqdn:
+                        type: string
+                      ips:
+                        items:
+                          type: string
+                        type: array
+                      setName:
+                        type: string
+                      version:
+                        type: string
+                    type: object
+                  type: array
+                description: FQDNState stores mapping from FQDN rules to nftables
+                  sets used for a firewall rule. Key is either MatchName or MatchPattern
+                type: object
+            type: object
         type: object
     served: true
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/charts/internal/shoot-control-plane/templates/firewall/rbac-firewall-controller.yaml
+++ b/charts/internal/shoot-control-plane/templates/firewall/rbac-firewall-controller.yaml
@@ -46,6 +46,7 @@ rules:
   - firewalls
   - firewalls/status
   - clusterwidenetworkpolicies
+  - clusterwidenetworkpolicies/status
   verbs:
   - list
   - get


### PR DESCRIPTION
Depends on:

- [x] https://github.com/metal-stack/firewall-controller/pull/82

Cached IP addresses are stored in the Clusterwidenetworkpolicy