### PR TITLE
`RestrictEgress` control plane feature gate.

### DIFF
--- a/charts/internal/shoot-control-plane/templates/network-policies.yaml
+++ b/charts/internal/shoot-control-plane/templates/network-policies.yaml
@@ -32,32 +32,6 @@ spec:
 apiVersion: metal-stack.io/v1
 kind: ClusterwideNetworkPolicy
 metadata:
-  name: allow-to-https
-  namespace: firewall
-spec:
-  egress:
-  - to:
-    - cidr: 0.0.0.0/0
-    ports:
-    - protocol: TCP
-      port: 443
----
-apiVersion: metal-stack.io/v1
-kind: ClusterwideNetworkPolicy
-metadata:
-  name: allow-to-http
-  namespace: firewall
-spec:
-  egress:
-  - to:
-    - cidr: 0.0.0.0/0
-    ports:
-    - protocol: TCP
-      port: 80
----
-apiVersion: metal-stack.io/v1
-kind: ClusterwideNetworkPolicy
-metadata:
   name: allow-to-ntp
   namespace: firewall
 spec:
@@ -88,6 +62,66 @@ spec:
     - cidr: {{ (split ":" $endpoint)._0 }}/32
 {{- end }}
 {{- end }}
+{{- if .Values.restrictEgress.enabled }}
+---
+apiVersion: metal-stack.io/v1
+kind: ClusterwideNetworkPolicy
+metadata:
+  name: allow-to-apiserver
+  namespace: firewall
+spec:
+  egress:
+  - toFQDNs:
+    - matchPattern: {{ quote .Values.restrictEgress.apiServerIngressDomain }}
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 8443
+    - protocol: TCP
+      port: 8132
+---
+apiVersion: metal-stack.io/v1
+kind: ClusterwideNetworkPolicy
+metadata:
+  name: allow-to-external-dependencies
+  namespace: firewall
+spec:
+  egress:
+{{- range $i, $dest := .Values.restrictEgress.destinations }}
+  - toFQDNs:
+    - matchPattern: {{ quote $dest.pattern }}
+{{- end }}
+    ports:
+    - protocol: TCP
+      port: {{ $dest.port }}
+{{- else }}
+---
+apiVersion: metal-stack.io/v1
+kind: ClusterwideNetworkPolicy
+metadata:
+  name: allow-to-https
+  namespace: firewall
+spec:
+  egress:
+  - to:
+    - cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 443
+---
+apiVersion: metal-stack.io/v1
+kind: ClusterwideNetworkPolicy
+metadata:
+  name: allow-to-http
+  namespace: firewall
+spec:
+  egress:
+  - to:
+    - cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 80
 {{- if gt (len .Values.apiserverIPs) 0 }}
 ---
 apiVersion: metal-stack.io/v1
@@ -108,4 +142,5 @@ spec:
       port: 8443
     - protocol: TCP
       port: 8132
+{{- end }}
 {{- end }}

--- a/charts/internal/shoot-control-plane/values.yaml
+++ b/charts/internal/shoot-control-plane/values.yaml
@@ -38,3 +38,10 @@ duros:
 
 clusterAudit:
   enabled: false
+
+restrictEgress:
+  enabled: false
+  apiServerIngressDomain: api.kube-apiserver
+  destinations:
+    - pattern: '*.a-name.org'
+      port: 443

--- a/pkg/apis/config/types.go
+++ b/pkg/apis/config/types.go
@@ -54,6 +54,12 @@ type ControllerConfiguration struct {
 
 	// ImagePullSecret provides an opportunity to inject an image pull secret into the resource deployments
 	ImagePullSecret *ImagePullSecret
+
+	// EgressDestinations is used when the RestrictedEgress control plane feature gate is enabled
+	// and provides additional egress destinations to the kube-apiserver.
+	//
+	// It is intended to be configured at least with container registries for the cluster.
+	EgressDestinations []EgressDest
 }
 
 // MachineImage is a mapping from logical names and versions to GCP-specific identifiers.
@@ -205,4 +211,13 @@ type DurosSeedStorageClass struct {
 type ImagePullSecret struct {
 	// DockerConfigJSON contains the already base64 encoded JSON content for the image pull secret
 	DockerConfigJSON string
+}
+
+type EgressDest struct {
+	// Description is a description for this egress destination.
+	Description string
+	// MatchPattern is the DNS match pattern for this destination.
+	MatchPattern string
+	// Port is the port for this destination.
+	Port int
 }

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -41,6 +41,12 @@ type ControllerConfiguration struct {
 
 	// ImagePullSecret provides an opportunity to inject an image pull secret into the resource deployments
 	ImagePullSecret *ImagePullSecret `json:"imagePullSecret,omitempty"`
+
+	// EgressDestinations is used when the RestrictedEgress control plane feature gate is enabled
+	// and provides additional egress destinations to the kube-apiserver.
+	//
+	// It is intended to be configured at least with container registries for the cluster.
+	EgressDestinations []EgressDest `json:"egressDestinations,omitempty"`
 }
 
 // MachineImage is a mapping from logical names and versions to GCP-specific identifiers.
@@ -196,4 +202,13 @@ type DurosSeedStorageClass struct {
 type ImagePullSecret struct {
 	// DockerConfigJSON contains the already base64 encoded JSON content for the image pull secret
 	DockerConfigJSON string `json:"encodedDockerConfigJSON"`
+}
+
+type EgressDest struct {
+	// Description is a description for this egress destination.
+	Description string `json:"description"`
+	// MatchPattern is the DNS match pattern for this destination.
+	MatchPattern string `json:"matchPattern"`
+	// Port is the port for this destination.
+	Port int `json:"port"`
 }

--- a/pkg/apis/metal/types_controlplane.go
+++ b/pkg/apis/metal/types_controlplane.go
@@ -53,6 +53,11 @@ type ControlPlaneFeatures struct {
 	// DurosStorageEncryption enables the deployment of configured encrypted storage classes for the duros-controller.
 	// +optional
 	DurosStorageEncryption *bool
+	// RestrictedEgress limits the cluster egress to the API server and necessary external dependencies (like container registries)
+	// by using DNS egress policies.
+	// Requires firewall-controller >= 1.2.0.
+	// +optional
+	RestrictedEgress *bool `json:"restrictedEgress,omitempty"`
 }
 
 // CloudControllerManagerConfig contains configuration settings for the cloud-controller-manager.

--- a/pkg/apis/metal/v1alpha1/types_controlplane.go
+++ b/pkg/apis/metal/v1alpha1/types_controlplane.go
@@ -53,6 +53,11 @@ type ControlPlaneFeatures struct {
 	// DurosStorageEncryption enables the deployment of configured encrypted storage classes for the duros-controller.
 	// +optional
 	DurosStorageEncryption *bool `json:"durosStorageEncryption,omitempty"`
+	// RestrictedEgress limits the cluster egress to the API server and necessary external dependencies (like container registries)
+	// by using DNS egress policies.
+	// Requires firewall-controller >= 1.2.0.
+	// +optional
+	RestrictedEgress *bool `json:"restrictedEgress,omitempty"`
 }
 
 // CloudControllerManagerConfig contains configuration settings for the cloud-controller-manager.


### PR DESCRIPTION
This drops the unrestricted egress cwnps for port 80 and 443 and instead deploys one cwnp for the kube-apiserver and one for external dependencies (like container registries, configurable through the controller configuration).