### PR TITLE
Mark speaker, csi-lvm-reviver and node-init as node-critical component

### DIFF
--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -316,6 +316,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
+    node.gardener.cloud/critical-component: "true"
     app: metallb
     component: speaker
   name: speaker
@@ -334,6 +335,7 @@ spec:
         app: metallb
         component: speaker
         projected-token-mount.resources.gardener.cloud/skip: "true"
+        node.gardener.cloud/critical-component: "true"
     spec:
       containers:
       - args:

--- a/charts/internal/shoot-control-plane/templates/node-init.yaml
+++ b/charts/internal/shoot-control-plane/templates/node-init.yaml
@@ -65,6 +65,7 @@ metadata:
   name: node-init
   namespace: kube-system
   labels:
+    node.gardener.cloud/critical-component: "true"
     app: node-init
 spec:
   selector:
@@ -73,6 +74,7 @@ spec:
   template:
     metadata:
       labels:
+        node.gardener.cloud/critical-component: "true"
         app: node-init
     spec:
       serviceAccount: node-init

--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -210,6 +210,8 @@ kind: DaemonSet
 metadata:
   name: csi-lvm-reviver
   namespace: csi-lvm
+  labels:
+    node.gardener.cloud/critical-component: "true"
 spec:
   selector:
     matchLabels:
@@ -217,6 +219,7 @@ spec:
   template:
     metadata:
       labels:
+        node.gardener.cloud/critical-component: "true"
         app: csi-lvm-reviver
     spec:
       serviceAccountName: csi-lvm-reviver


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds the `node.gardener.cloud/critical-component` label to `speaker`, `csi-lvm-reviver` and `node-init` DaemonSet introduced in https://github.com/gardener/gardener/pull/7406 

**Which issue(s) this PR fixes**:
Part of  https://github.com/gardener/gardener/issues/7117

**Special notes for your reviewer**:
https://github.com/gardener/gardener/pull/7406 is merged
