### PR TITLE
Fix build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ generate: $(HELM)
 .PHONY: generate-in-docker
 generate-in-docker: revendor $(HELM)
 	echo $(shell git describe --abbrev=0 --tags) > VERSION
-	docker run --rm -i$(DOCKER_TTY_ARG) -v $(PWD):/go/src/github.com/metal-stack/gardener-extension-provider-metal golang:1.19 \
+	docker run --rm -i$(DOCKER_TTY_ARG) -v $(PWD):/go/src/github.com/metal-stack/gardener-extension-provider-metal golang:1.19.4 \
 		sh -c "cd /go/src/github.com/metal-stack/gardener-extension-provider-metal \
 				&& make install generate \
 				&& chown -R $(shell id -u):$(shell id -g) ."

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ test:
 
 .PHONY: test-in-docker
 test-in-docker: revendor
-	docker run --rm -i$(DOCKER_TTY_ARG) -v $(PWD):/go/src/github.com/metal-stack/gardener-extension-provider-metal golang:1.19 \
+	docker run --rm -i$(DOCKER_TTY_ARG) -v $(PWD):/go/src/github.com/metal-stack/gardener-extension-provider-metal golang:1.19.4 \
 		sh -c "cd /go/src/github.com/metal-stack/gardener-extension-provider-metal \
 				&& make install check test"
 


### PR DESCRIPTION
Because some changes introduced with >= go-1.19.5 `make generate-in-docker` does not work anymore, fix this.