### PR TITLE
Optional iam config for authn webhook.

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -1198,7 +1198,13 @@ func getAuthNGroupRoleChartValues(cpConfig *apismetal.ControlPlaneConfig, cluste
 	annotations := cluster.Shoot.GetAnnotations()
 	clusterName := annotations[tag.ClusterName]
 
-	ti := cpConfig.IAMConfig.IssuerConfig
+	issuerUrl := ""
+	issuerClientID := ""
+
+	if cpConfig.IAMConfig != nil && cpConfig.IAMConfig.IssuerConfig != nil {
+		issuerUrl = cpConfig.IAMConfig.IssuerConfig.Url
+		issuerClientID = cpConfig.IAMConfig.IssuerConfig.ClientId
+	}
 
 	values := map[string]interface{}{
 		"authnWebhook": map[string]interface{}{
@@ -1208,8 +1214,8 @@ func getAuthNGroupRoleChartValues(cpConfig *apismetal.ControlPlaneConfig, cluste
 			"providerTenant": config.ProviderTenant,
 			"clusterName":    clusterName,
 			"oidc": map[string]interface{}{
-				"issuerUrl":      ti.Url,
-				"issuerClientId": ti.ClientId,
+				"issuerUrl":      issuerUrl,
+				"issuerClientId": issuerClientID,
 			},
 			"metalapi": map[string]interface{}{
 				"url":            metalAccess.url,


### PR DESCRIPTION
Allows to set issuer url and client id to empty string, effectively allowing to unconfigure dex.