### PR TITLE
Migrate to shoot access token and generic kubeconfig for accounting-exporter

### DIFF
--- a/charts/internal/control-plane/templates/accounting-exporter.yaml
+++ b/charts/internal/control-plane/templates/accounting-exporter.yaml
@@ -88,7 +88,7 @@ spec:
         - name: KUBE_COUNTER_CLUSTER_NAME
           value: {{ .Values.accountingExporter.enrichments.clusterName }}
         - name: KUBE_COUNTER_KUBECONFIG
-          value: /var/lib/accounting-exporter/kubeconfig
+          value: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
         - name: KUBE_COUNTER_ACCOUNTING_API_HOSTNAME
           value: {{ .Values.accountingExporter.accountingAPI.hostname }}
         - name: KUBE_COUNTER_ACCOUNTING_API_PORT
@@ -96,18 +96,32 @@ spec:
         - name: KUBE_COUNTER_NETWORK_TRAFFIC_ENABLED
           value: "{{ .Values.accountingExporter.networkTraffic.enabled }}"
         volumeMounts:
-        - name: accounting-exporter
-          mountPath: /var/lib/accounting-exporter
+        - mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig
+          name: kubeconfig
+          readOnly: true
         - mountPath: /certs
           name: certs
       restartPolicy: Always
       volumes:
-      - name: accounting-exporter
-        secret:
-          secretName: accounting-exporter
       - name: certs
         secret:
           secretName: accounting-exporter-tls
+      - name: kubeconfig
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: kubeconfig
+                path: kubeconfig
+              name: {{ .Values.genericTokenKubeconfigSecretName }}
+              optional: false
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: shoot-access-accounting-exporter
+              optional: false
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/internal/shoot-control-plane/templates/rbac-accounting-controller.yaml
+++ b/charts/internal/shoot-control-plane/templates/rbac-accounting-controller.yaml
@@ -46,7 +46,7 @@ roleRef:
   kind: ClusterRole
   name: system:accounting-exporter
 subjects:
-- kind: User
-  name: system:accounting-exporter
-  apiGroup: ""
+- kind: ServiceAccount
+  name: accounting-exporter
+  namespace: kube-system
 {{- end }}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -131,23 +131,6 @@ var controlPlaneSecrets = &secrets.Secrets{
 				},
 			},
 			&secrets.ControlPlaneSecretConfig{
-				Name: metal.AccountingExporterName,
-				CertificateSecretConfig: &secrets.CertificateSecretConfig{
-					Name:       metal.AccountingExporterName,
-					CommonName: "system:accounting-exporter",
-					// Groupname of user
-					Organization: []string{metal.AccountingExporterName},
-					CertType:     secrets.ClientCert,
-					SigningCA:    cas[v1alpha1constants.SecretNameCACluster],
-				},
-				KubeConfigRequests: []secrets.KubeConfigRequest{
-					{
-						ClusterName:   clusterName,
-						APIServerHost: v1alpha1constants.DeploymentNameKubeAPIServer,
-					},
-				},
-			},
-			&secrets.ControlPlaneSecretConfig{
 				Name: metal.CloudControllerManagerServerName,
 				CertificateSecretConfig: &secrets.CertificateSecretConfig{
 					Name:       metal.CloudControllerManagerServerName,
@@ -174,6 +157,7 @@ var controlPlaneSecrets = &secrets.Secrets{
 func shootAccessSecretsFunc(namespace string) []*gutil.ShootAccessSecret {
 	return []*gutil.ShootAccessSecret{
 		gutil.NewShootAccessSecret(metal.FirewallControllerManagerDeploymentName, namespace),
+		gutil.NewShootAccessSecret(metal.AccountingExporterName, namespace),
 	}
 }
 


### PR DESCRIPTION
References #276.