### PR TITLE
Align access of the node cidr in reconciliations.

### DIFF
--- a/pkg/apis/metal/helper/helper.go
+++ b/pkg/apis/metal/helper/helper.go
@@ -3,6 +3,9 @@ package helper
 import (
 	"fmt"
 
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
 	"github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/metal"
 
 	corev1 "k8s.io/api/core/v1"
@@ -41,4 +44,22 @@ func ImagePullPolicyFromString(policy string) corev1.PullPolicy {
 	default:
 		return corev1.PullIfNotPresent
 	}
+}
+
+// GetNodeCIDR returns the node cidr from the shoot spec. if this is not yet set, it returns the
+// node cidr from the infrastructure status. if it's set nowhere, it returns an error.
+func GetNodeCIDR(infrastructure *extensionsv1alpha1.Infrastructure, cluster *extensionscontroller.Cluster) (string, error) {
+	var nodeCIDR string
+
+	if cluster.Shoot.Spec.Networking.Nodes != nil {
+		nodeCIDR = *cluster.Shoot.Spec.Networking.Nodes
+	} else if infrastructure != nil && infrastructure.Status.NodesCIDR != nil {
+		nodeCIDR = *infrastructure.Status.NodesCIDR
+	}
+
+	if nodeCIDR == "" {
+		return "", fmt.Errorf("nodeCIDR is not yet set")
+	}
+
+	return nodeCIDR, nil
 }

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -595,8 +595,9 @@ func (vp *valuesProvider) GetControlPlaneShootChartValues(ctx context.Context, c
 func (vp *valuesProvider) getControlPlaneShootChartValues(ctx context.Context, metalControlPlane *apismetal.MetalControlPlane, cpConfig *apismetal.ControlPlaneConfig, cluster *extensionscontroller.Cluster, nws networkMap, infrastructure *extensionsv1alpha1.Infrastructure, infrastructureConfig *apismetal.InfrastructureConfig, mclient metalgo.Client) (map[string]interface{}, error) {
 	namespace := cluster.ObjectMeta.Name
 
-	if infrastructure == nil || infrastructure.Status.NodesCIDR == nil {
-		return nil, fmt.Errorf("nodeCIDR was not yet set by infrastructure controller")
+	nodeCIDR, err := helper.GetNodeCIDR(infrastructure, cluster)
+	if err != nil {
+		return nil, err
 	}
 
 	fwSpec, err := vp.getFirewallSpec(ctx, metalControlPlane, infrastructureConfig, cluster, nws, mclient)
@@ -676,7 +677,7 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(ctx context.Context, m
 		"imagePullPolicy":   helper.ImagePullPolicyFromString(vp.controllerConfig.ImagePullPolicy),
 		"kubernetesVersion": cluster.Shoot.Spec.Kubernetes.Version,
 		"apiserverIPs":      apiserverIPs,
-		"nodeCIDR":          *infrastructure.Status.NodesCIDR,
+		"nodeCIDR":          nodeCIDR,
 		"firewallSpec":      fwSpec,
 		"duros":             durosValues,
 		"clusterAudit":      clusterAuditValues,
@@ -1014,16 +1015,13 @@ func getCCMChartValues(
 	secretsReader secretsmanager.Reader,
 ) (map[string]interface{}, error) {
 	projectID := infrastructureConfig.ProjectID
-	nodeCIDR := infrastructure.Status.NodesCIDR
 
-	if nodeCIDR == nil {
-		if cluster.Shoot.Spec.Networking.Nodes == nil {
-			return nil, fmt.Errorf("nodeCIDR was not yet set by infrastructure controller")
-		}
-		nodeCIDR = cluster.Shoot.Spec.Networking.Nodes
+	nodeCIDR, err := helper.GetNodeCIDR(infrastructure, cluster)
+	if err != nil {
+		return nil, err
 	}
 
-	privateNetwork, err := metalclient.GetPrivateNetworkFromNodeNetwork(ctx, mclient, projectID, *nodeCIDR)
+	privateNetwork, err := metalclient.GetPrivateNetworkFromNodeNetwork(ctx, mclient, projectID, nodeCIDR)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -124,16 +124,13 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 	}
 
 	projectID := infrastructureConfig.ProjectID
-	nodeCIDR := infrastructure.Status.NodesCIDR
 
-	if nodeCIDR == nil {
-		if w.cluster.Shoot.Spec.Networking.Nodes == nil {
-			return fmt.Errorf("nodeCIDR was not yet set by infrastructure controller")
-		}
-		nodeCIDR = w.cluster.Shoot.Spec.Networking.Nodes
+	nodeCIDR, err := helper.GetNodeCIDR(infrastructure, w.cluster)
+	if err != nil {
+		return err
 	}
 
-	privateNetwork, err := metalclient.GetPrivateNetworkFromNodeNetwork(ctx, mclient, projectID, *nodeCIDR)
+	privateNetwork, err := metalclient.GetPrivateNetworkFromNodeNetwork(ctx, mclient, projectID, nodeCIDR)
 	if err != nil {
 		return err
 	}

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -74,8 +74,9 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 		return err
 	}
 
-	if infrastructure == nil || infrastructure.Status.NodesCIDR == nil {
-		return fmt.Errorf("nodeCIDR was not yet set by infrastructure controller")
+	nodeCIDR, err := helper.GetNodeCIDR(infrastructure, cluster)
+	if err != nil {
+		return err
 	}
 
 	makeAuditForwarder := false
@@ -107,7 +108,7 @@ func (e *ensurer) EnsureKubeAPIServerDeployment(ctx context.Context, gctx gconte
 		ensureVolumes(ps, makeAuditForwarder, auditToSplunk)
 	}
 	if c := extensionswebhook.ContainerWithName(ps.Containers, "vpn-seed"); c != nil {
-		ensureVPNSeedEnvVars(c, *infrastructure.Status.NodesCIDR)
+		ensureVPNSeedEnvVars(c, nodeCIDR)
 	}
 	if makeAuditForwarder {
 		err := ensureAuditForwarder(ps, auditToSplunk)
@@ -508,15 +509,16 @@ func (e *ensurer) EnsureVPNSeedServerDeployment(ctx context.Context, gctx gconte
 		return err
 	}
 
-	if infrastructure == nil || infrastructure.Status.NodesCIDR == nil {
-		return fmt.Errorf("nodeCIDR was not yet set by infrastructure controller")
+	nodeCIDR, err := helper.GetNodeCIDR(infrastructure, cluster)
+	if err != nil {
+		return err
 	}
 
 	template := &new.Spec.Template
 	ps := &template.Spec
 
 	if c := extensionswebhook.ContainerWithName(ps.Containers, "vpn-seed-server"); c != nil {
-		ensureVPNSeedEnvVars(c, *infrastructure.Status.NodesCIDR)
+		ensureVPNSeedEnvVars(c, nodeCIDR)
 	}
 
 	return nil


### PR DESCRIPTION
This is a preparation for smooth shoot migration. It makes the reconciliations use the node cidr from the shoot spec and falls back to the infrastructure status node cidr at all places. This is useful as the infrastructure status gets lost on shoot migration.

References #275.