### PR TITLE
csi-lvm missing some PVC permissions.

### DIFF
--- a/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -36,6 +36,8 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
I don't exactly understand why, but this issue was coming up on a K8s 1.25 seed:

```
"shoot--f8e67080ba--robert/etcd-events-etcd-events-0": persistentvolumeclaims "etcd-events-etcd-events-0" is forbidden: User "system:serviceaccount:csi-lvm:csi-lvm-controller" cannot update resource "persistentvolumeclaims" in API group "" in the namespace "shoot--f8e67080ba--robert"
```

