### PR TITLE
Use first external network as default for cloud controller manager.

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -1243,11 +1243,6 @@ func getDefaultExternalNetwork(nws networkMap, cpConfig *apismetal.ControlPlaneC
 
 		networkID := *cpConfig.CloudControllerManager.DefaultExternalNetwork
 
-		_, ok := nws[networkID]
-		if !ok {
-			return "", fmt.Errorf("given default external network defined in cloud-controller-manager control plane config does not exist in metal-api")
-		}
-
 		if !slices.Contains(infrastructureConfig.Firewall.Networks, networkID) {
 			return "", fmt.Errorf("given default external network not contained in firewall networks")
 		}

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -917,61 +917,9 @@ func getCCMChartValues(
 		return nil, err
 	}
 
-	// TODO @majst01: Refactor a bit
-	var defaultExternalNetwork string
-	if cpConfig.CloudControllerManager != nil && cpConfig.CloudControllerManager.DefaultExternalNetwork != nil {
-		defaultExternalNetwork = *cpConfig.CloudControllerManager.DefaultExternalNetwork
-		resp, err := mclient.Network().FindNetwork(network.NewFindNetworkParams().WithID(defaultExternalNetwork).WithContext(ctx), nil)
-		if err != nil {
-			return nil, fmt.Errorf("could not retrieve user-given default external network: %s %w", defaultExternalNetwork, err)
-		}
-
-		if resp.Payload.Shared && resp.Payload.Partitionid != infrastructureConfig.PartitionID {
-			return nil, fmt.Errorf("shared external network must be in same partition as shoot")
-		}
-
-		if resp.Payload.Projectid != "" && resp.Payload.Projectid != infrastructureConfig.ProjectID && !resp.Payload.Shared {
-			return nil, fmt.Errorf("cannot define default external unshared network of another project")
-		}
-
-		if (resp.Payload.Underlay != nil && *resp.Payload.Underlay) || (resp.Payload.Privatesuper != nil && *resp.Payload.Privatesuper) {
-			return nil, fmt.Errorf("cannot declare underlay or private super networks as default external network")
-		}
-	} else {
-		if pointer.SafeDeref(cpConfig.NetworkAccessType) == apismetal.NetworkAccessForbidden {
-			// set no default network!
-		} else {
-			var dmzNetwork string
-			for _, networkID := range infrastructureConfig.Firewall.Networks {
-				nw, ok := nws[networkID]
-				if !ok {
-					return nil, fmt.Errorf("network defined in firewall networks does not exist in metal-api")
-				}
-				for k := range nw.Labels {
-					if k == tag.NetworkDefaultExternal {
-						if nw.Parentnetworkid != "" {
-							pn, ok := nws[nw.Parentnetworkid]
-							if !ok {
-								return nil, fmt.Errorf("network defined in firewall networks specified a parent network that does not exist in metal-api")
-							}
-							if *pn.Privatesuper {
-								dmzNetwork = networkID
-							}
-						} else {
-							defaultExternalNetwork = networkID
-						}
-						break
-					}
-				}
-			}
-			// fallback to a dmz network with the NetworkDefaultExternal tag
-			if defaultExternalNetwork == "" && dmzNetwork != "" {
-				defaultExternalNetwork = dmzNetwork
-			}
-			if defaultExternalNetwork == "" {
-				return nil, fmt.Errorf("unable to find a default external network for metal-ccm deployment")
-			}
-		}
+	defaultExternalNetwork, err := getDefaultNetwork(nws, cpConfig, infrastructureConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	serverSecret, found := secretsReader.Get(metal.CloudControllerManagerServerName)
@@ -1286,4 +1234,80 @@ func registryMirrorToValueMap(r apismetal.RegistryMirror) (map[string]any, error
 		"cidr":     registryIP,
 		"port":     r.Port,
 	}, nil
+}
+
+func getDefaultNetwork(nws networkMap, cpConfig *apismetal.ControlPlaneConfig, infrastructureConfig *apismetal.InfrastructureConfig) (string, error) {
+	if cpConfig.CloudControllerManager != nil && cpConfig.CloudControllerManager.DefaultExternalNetwork != nil {
+		// user has set a specific default external network, check if it's valid
+
+		nw, ok := nws[*cpConfig.CloudControllerManager.DefaultExternalNetwork]
+		if !ok {
+			return "", fmt.Errorf("given default external network defined in cloud-controller-manager control plane config does not exist in metal-api")
+		}
+
+		if nw.Shared && nw.Partitionid != infrastructureConfig.PartitionID {
+			return "", fmt.Errorf("shared external network must be in same partition as shoot")
+		}
+
+		if nw.Projectid != "" && nw.Projectid != infrastructureConfig.ProjectID && !nw.Shared {
+			return "", fmt.Errorf("cannot define default external unshared network of another project")
+		}
+
+		if (nw.Underlay != nil && *nw.Underlay) || (nw.Privatesuper != nil && *nw.Privatesuper) {
+			return "", fmt.Errorf("cannot declare underlay or private super networks as default external network")
+		}
+
+		return *cpConfig.CloudControllerManager.DefaultExternalNetwork, nil
+	}
+
+	if pointer.SafeDeref(cpConfig.NetworkAccessType) == apismetal.NetworkAccessForbidden {
+		// for isolated clusters with forbidden access type it makes no sense to define a default external network because connections will not be allowed automatically anyway
+		return "", nil
+	}
+
+	var (
+		externalNetworks []string
+		// dmzNetworks are deprecated, this can be removed after all users had enough time to migrate to isolated clusters
+		dmzNetworks []string
+	)
+
+	for _, networkID := range infrastructureConfig.Firewall.Networks {
+		nw, ok := nws[networkID]
+		if !ok {
+			return "", fmt.Errorf("network defined in firewall networks does not exist in metal-api")
+		}
+
+		_, ok = nw.Labels[tag.NetworkDefaultExternal]
+		if !ok {
+			continue
+		}
+
+		if nw.Parentnetworkid == "" {
+			externalNetworks = append(externalNetworks, networkID)
+			continue
+		}
+
+		pn, ok := nws[nw.Parentnetworkid]
+		if !ok {
+			return "", fmt.Errorf("network defined in firewall networks specified a parent network that does not exist in metal-api")
+		}
+
+		if *pn.Privatesuper {
+			dmzNetworks = append(dmzNetworks, networkID)
+			continue
+		}
+	}
+
+	if len(externalNetworks) != 0 {
+		// if there is an external network we prefer this over DMZ networks
+		// if there are multiple external networks it's impossible to distinguish which one to choose, so we use the first one defined in the list
+		return externalNetworks[0], nil
+	}
+
+	if len(dmzNetworks) != 0 {
+		// if there are multiple dmz networks it's impossible to distinguish which one to choose, so we use the first one defined in the list
+		return dmzNetworks[0], nil
+	}
+
+	return "", nil
 }

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -1257,8 +1257,7 @@ func getDefaultExternalNetwork(nws networkMap, cpConfig *apismetal.ControlPlaneC
 
 	var (
 		externalNetworks []*models.V1NetworkResponse
-		// dmzNetworks are deprecated, this can be removed after all users had enough time to migrate to isolated clusters
-		dmzNetworks []*models.V1NetworkResponse
+		dmzNetworks      []*models.V1NetworkResponse // dmzNetworks are deprecated, this can be removed after all users had enough time to migrate to isolated clusters
 	)
 
 	for _, networkID := range infrastructureConfig.Firewall.Networks {

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -44,7 +45,6 @@ import (
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/strings/slices"
 
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -918,7 +918,7 @@ func getCCMChartValues(
 		return nil, err
 	}
 
-	defaultExternalNetwork, err := getDefaultNetwork(nws, cpConfig, infrastructureConfig)
+	defaultExternalNetwork, err := getDefaultExternalNetwork(nws, cpConfig, infrastructureConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -1237,7 +1237,7 @@ func registryMirrorToValueMap(r apismetal.RegistryMirror) (map[string]any, error
 	}, nil
 }
 
-func getDefaultNetwork(nws networkMap, cpConfig *apismetal.ControlPlaneConfig, infrastructureConfig *apismetal.InfrastructureConfig) (string, error) {
+func getDefaultExternalNetwork(nws networkMap, cpConfig *apismetal.ControlPlaneConfig, infrastructureConfig *apismetal.InfrastructureConfig) (string, error) {
 	if cpConfig.CloudControllerManager != nil && cpConfig.CloudControllerManager.DefaultExternalNetwork != nil {
 		// user has set a specific default external network, check if it's valid
 

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -1,6 +1,7 @@
 package controlplane
 
 import (
+	"fmt"
 	"reflect"
 	"slices"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	apismetal "github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/metal"
 	"github.com/metal-stack/metal-go/api/models"
 	"github.com/metal-stack/metal-lib/pkg/pointer"
+	"github.com/metal-stack/metal-lib/pkg/tag"
 	"github.com/metal-stack/metal-lib/pkg/testcommon"
 )
 
@@ -124,6 +126,123 @@ func Test_registryMirrorToValueMap(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("registryMirrorToValueMap() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getDefaultNetwork(t *testing.T) {
+	var (
+		internetFirewall = &apismetal.InfrastructureConfig{
+			PartitionID: "a",
+			ProjectID:   "own-project",
+			Firewall: apismetal.Firewall{
+				Networks: []string{
+					"internet",
+					"own-external-network",
+				},
+			},
+		}
+
+		dmzFirewall = &apismetal.InfrastructureConfig{
+			PartitionID: "a",
+			ProjectID:   "own-project",
+			Firewall: apismetal.Firewall{
+				Networks: []string{
+					"dmz-network",
+				},
+			},
+		}
+
+		nws = networkMap{
+			"own-external-network": &models.V1NetworkResponse{
+				ID:              pointer.Pointer("own-external-network"),
+				Parentnetworkid: "",
+				Projectid:       "own-project",
+			},
+			"somebody-external-network": &models.V1NetworkResponse{
+				ID:              pointer.Pointer("somebody-external-network"),
+				Parentnetworkid: "",
+				Projectid:       "another-project",
+			},
+			"internet": &models.V1NetworkResponse{
+				ID:              pointer.Pointer("internet"),
+				Parentnetworkid: "",
+				Labels: map[string]string{
+					tag.NetworkDefaultExternal: "",
+				},
+			},
+			"dmz-network": &models.V1NetworkResponse{
+				ID:              pointer.Pointer("dmz-network"),
+				Parentnetworkid: "super-network",
+				Projectid:       "own-project",
+				Shared:          true,
+				Labels: map[string]string{
+					tag.NetworkDefaultExternal: "",
+				},
+			},
+			"super-network": &models.V1NetworkResponse{
+				ID:           pointer.Pointer("super-network"),
+				Projectid:    "",
+				Privatesuper: pointer.Pointer(true),
+			},
+		}
+	)
+
+	tests := []struct {
+		name                 string
+		nws                  networkMap
+		cpConfig             *apismetal.ControlPlaneConfig
+		infrastructureConfig *apismetal.InfrastructureConfig
+		want                 string
+		wantErr              error
+	}{
+		{
+			name:                 "specific default external network as specified by user",
+			nws:                  nws,
+			infrastructureConfig: internetFirewall,
+			cpConfig: &apismetal.ControlPlaneConfig{
+				CloudControllerManager: &apismetal.CloudControllerManagerConfig{
+					DefaultExternalNetwork: pointer.Pointer("own-external-network"),
+				},
+			},
+			want: "own-external-network",
+		},
+		{
+			name:                 "cannot specify external network of somebody else",
+			nws:                  nws,
+			infrastructureConfig: internetFirewall,
+			cpConfig: &apismetal.ControlPlaneConfig{
+				CloudControllerManager: &apismetal.CloudControllerManagerConfig{
+					DefaultExternalNetwork: pointer.Pointer("somebody-external-network"),
+				},
+			},
+			wantErr: fmt.Errorf("given default external network not contained in firewall networks"),
+		},
+		{
+			name:                 "use first external network",
+			nws:                  nws,
+			infrastructureConfig: internetFirewall,
+			cpConfig:             &apismetal.ControlPlaneConfig{},
+			want:                 "internet",
+		},
+		{
+			name:                 "fallback to dmz network",
+			nws:                  nws,
+			infrastructureConfig: dmzFirewall,
+			cpConfig:             &apismetal.ControlPlaneConfig{},
+			want:                 "dmz-network",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getDefaultNetwork(tt.nws, tt.cpConfig, tt.infrastructureConfig)
+			if diff := cmp.Diff(tt.wantErr, err, testcommon.ErrorStringComparer()); diff != "" {
+				t.Errorf("error diff (+got -want):\n %s", diff)
+			}
+
+			if diff := cmp.Diff(got, tt.want, testcommon.StrFmtDateComparer()); diff != "" {
+				t.Errorf("diff (+got -want):\n %s", diff)
 			}
 		})
 	}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -131,7 +131,7 @@ func Test_registryMirrorToValueMap(t *testing.T) {
 	}
 }
 
-func Test_getDefaultNetwork(t *testing.T) {
+func Test_getDefaultExternalNetwork(t *testing.T) {
 	var (
 		internetFirewall = &apismetal.InfrastructureConfig{
 			PartitionID: "a",
@@ -245,7 +245,7 @@ func Test_getDefaultNetwork(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := getDefaultNetwork(tt.nws, tt.cpConfig, tt.infrastructureConfig)
+			got, err := getDefaultExternalNetwork(tt.nws, tt.cpConfig, tt.infrastructureConfig)
 			if diff := cmp.Diff(tt.wantErr, err, testcommon.ErrorStringComparer()); diff != "" {
 				t.Errorf("error diff (+got -want):\n %s", diff)
 			}

--- a/pkg/controller/controlplane/valuesprovider_test.go
+++ b/pkg/controller/controlplane/valuesprovider_test.go
@@ -138,8 +138,9 @@ func Test_getDefaultNetwork(t *testing.T) {
 			ProjectID:   "own-project",
 			Firewall: apismetal.Firewall{
 				Networks: []string{
-					"internet",
+					"mpls-network",
 					"own-external-network",
+					"internet",
 				},
 			},
 		}
@@ -167,6 +168,14 @@ func Test_getDefaultNetwork(t *testing.T) {
 			},
 			"internet": &models.V1NetworkResponse{
 				ID:              pointer.Pointer("internet"),
+				Parentnetworkid: "",
+				Labels: map[string]string{
+					tag.NetworkDefaultExternal: "",
+					tag.NetworkDefault:         "",
+				},
+			},
+			"mpls-network": &models.V1NetworkResponse{
+				ID:              pointer.Pointer("mpls-network"),
 				Parentnetworkid: "",
 				Labels: map[string]string{
 					tag.NetworkDefaultExternal: "",
@@ -220,7 +229,7 @@ func Test_getDefaultNetwork(t *testing.T) {
 			wantErr: fmt.Errorf("given default external network not contained in firewall networks"),
 		},
 		{
-			name:                 "use first external network",
+			name:                 "use internet as default external network",
 			nws:                  nws,
 			infrastructureConfig: internetFirewall,
 			cpConfig:             &apismetal.ControlPlaneConfig{},


### PR DESCRIPTION
At the moment in the complex algorithm we use the last external network defined in the firewall network list, which I think is counter-intuitive. This PR defaults to network with the default label if multiple networks with default-external label exist.