### PR TITLE
Allow firewall-controller-manager to patch infrastructure egressCIDRs.

### DIFF
--- a/charts/internal/control-plane/templates/firewall-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/firewall-controller-manager.yaml
@@ -68,6 +68,18 @@ rules:
   - update
   - patch
   - create
+- apiGroups:
+  - extensions.gardener.cloud
+  resources:
+  - infrastructures
+  verbs:
+  - get
+- apiGroups:
+  - extensions.gardener.cloud
+  resources:
+  - infrastructures/status
+  verbs:
+  - patch
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/internal/control-plane/templates/firewall-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/firewall-controller-manager.yaml
@@ -72,6 +72,7 @@ rules:
   - extensions.gardener.cloud
   resources:
   - infrastructures
+  - extensions
   verbs:
   - get
 - apiGroups:
@@ -80,6 +81,12 @@ rules:
   - infrastructures/status
   verbs:
   - patch
+- apiGroups:
+  - extensions.gardener.cloud
+  resources:
+  - extensions
+  verbs:
+  - update
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
References https://github.com/metal-stack/firewall-controller-manager/pull/61.