### PR TITLE
Use kubelet path configuration constant.

### DIFF
--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -228,7 +228,7 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 
 	var files []extensionsv1alpha1.File
 	for _, f := range *new {
-		if f.Path == "/var/lib/kubelet/config/kubelet" {
+		if f.Path == v1beta1constants.OperatingSystemConfigFilePathKubeletConfig {
 			// for cis benchmark this needs to be 600
 			f.Permissions = pointer.Pointer(int32(0600))
 		}


### PR DESCRIPTION
## References

Follow-up of https://github.com/metal-stack/gardener-extension-provider-metal/pull/423.

<!--
Thanks for opening a pull request in the metal-stack org! 😻
If you haven't done already, feel free to check our contribution guidelines on docs.metal-stack.io.

If possible, please reference other issues or pull requests. If this PR closes an issue, please add:

Closes #<the-issue-number-to-close>.

If you want to reference other issues, please add:

References:

- ...

If your PR depends on other PRs, please add:

Depends on:

- [ ] ...
-->

## Additional Description

None

<!--
If not already described in a referenced issue, please describe your PR and the motivation behind it. You can also add special notes for the reviewers here, e.g. why you solved the problem in a certain why or give an overview over the your changes and implications. Just try to make life easy for the reviewers.
-->

## Release Notes

None

<!--
Do you want to add something to the release notes (metal-stack/releases)? You can do so by adding special sections in this PR.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable and choose wisely.

If your changes contain a breaking change, please add the following section:

## Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

If your changes contain required actions for operators, please add the following section:

## Required Actions

```ACTIONS_REQUIRED
Description of the required action.
```
-->
