### PR TITLE
Fix no default storage class when csi-lvm is disabled.

### DIFF
--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -1171,11 +1171,7 @@ func setDurosDefaultStorageClass(scs []map[string]any, fg *apismetal.ControlPlan
 		)
 
 		if replicasI == replicasJ {
-			if encryptionI && !encryptionJ {
-				return false
-			}
-
-			return true
+			return !encryptionI && encryptionJ
 		}
 
 		return replicasI > replicasJ


### PR DESCRIPTION
## Description

When csi-lvm is disabled, we do not declare a default storage class anymore. References #438.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
