### PR TITLE
Configure cluster isolation container registries through mutating hook.

### DIFF
--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -1,0 +1,177 @@
+package controlplane
+
+import (
+	"testing"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/google/go-cmp/cmp"
+	apimetal "github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/metal"
+	"github.com/metal-stack/metal-lib/pkg/pointer"
+)
+
+func Test_ensureContainerdRegistries(t *testing.T) {
+	tests := []struct {
+		name    string
+		mirrors []apimetal.RegistryMirror
+		configs []extensionsv1alpha1.RegistryConfig
+		want    []extensionsv1alpha1.RegistryConfig
+	}{
+		{
+			name:    "maintain existing config",
+			mirrors: nil,
+			configs: []extensionsv1alpha1.RegistryConfig{
+				{
+					Upstream: "https://registry-b",
+					Hosts: []extensionsv1alpha1.RegistryHost{
+						{
+							URL:          "eu.gcr.io",
+							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
+						},
+					},
+				},
+			},
+			want: []extensionsv1alpha1.RegistryConfig{
+				{
+					Upstream: "https://registry-b",
+					Hosts: []extensionsv1alpha1.RegistryHost{
+						{
+							URL:          "eu.gcr.io",
+							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "add new config",
+			mirrors: []apimetal.RegistryMirror{
+				{
+					Name:     "test registry",
+					Endpoint: "https://registry-a",
+					IP:       "1.1.1.1",
+					Port:     443,
+					MirrorOf: []string{"quay.io"},
+				},
+			},
+			configs: nil,
+			want: []extensionsv1alpha1.RegistryConfig{
+				{
+					Upstream: "https://registry-a",
+					Hosts: []extensionsv1alpha1.RegistryHost{
+						{
+							URL:          "quay.io",
+							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability, extensionsv1alpha1.ResolveCapability},
+						},
+					},
+					ReadinessProbe: pointer.Pointer(false),
+				},
+			},
+		},
+		{
+			name: "update outdated config",
+			mirrors: []apimetal.RegistryMirror{
+				{
+					Name:     "test registry",
+					Endpoint: "https://registry-a",
+					IP:       "1.1.1.1",
+					Port:     443,
+					MirrorOf: []string{"quay.io"},
+				},
+			},
+			configs: []extensionsv1alpha1.RegistryConfig{
+				{
+					Upstream: "https://registry-a",
+					Hosts: []extensionsv1alpha1.RegistryHost{
+						{
+							URL:          "old.quay.io",
+							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability, extensionsv1alpha1.ResolveCapability},
+						},
+					},
+					ReadinessProbe: pointer.Pointer(false),
+				},
+				{
+					Upstream: "https://registry-b",
+					Hosts: []extensionsv1alpha1.RegistryHost{
+						{
+							URL:          "eu.gcr.io",
+							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
+						},
+					},
+				},
+			},
+			want: []extensionsv1alpha1.RegistryConfig{
+				{
+					Upstream: "https://registry-a",
+					Hosts: []extensionsv1alpha1.RegistryHost{
+						{
+							URL:          "quay.io",
+							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability, extensionsv1alpha1.ResolveCapability},
+						},
+					},
+					ReadinessProbe: pointer.Pointer(false),
+				},
+				{
+					Upstream: "https://registry-b",
+					Hosts: []extensionsv1alpha1.RegistryHost{
+						{
+							URL:          "eu.gcr.io",
+							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "append to existing config",
+			mirrors: []apimetal.RegistryMirror{
+				{
+					Name:     "test registry",
+					Endpoint: "https://registry-a",
+					IP:       "1.1.1.1",
+					Port:     443,
+					MirrorOf: []string{"quay.io"},
+				},
+			},
+			configs: []extensionsv1alpha1.RegistryConfig{
+				{
+					Upstream: "https://registry-b",
+					Hosts: []extensionsv1alpha1.RegistryHost{
+						{
+							URL:          "eu.gcr.io",
+							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
+						},
+					},
+				},
+			},
+			want: []extensionsv1alpha1.RegistryConfig{
+				{
+					Upstream: "https://registry-b",
+					Hosts: []extensionsv1alpha1.RegistryHost{
+						{
+							URL:          "eu.gcr.io",
+							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
+						},
+					},
+				},
+				{
+					Upstream: "https://registry-a",
+					Hosts: []extensionsv1alpha1.RegistryHost{
+						{
+							URL:          "quay.io",
+							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability, extensionsv1alpha1.ResolveCapability},
+						},
+					},
+					ReadinessProbe: pointer.Pointer(false),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ensureContainerdRegistries(tt.mirrors, tt.configs)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("diff = %s", diff)
+			}
+		})
+	}
+}

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	apimetal "github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/metal"
 	"github.com/metal-stack/metal-lib/pkg/pointer"
-	"github.com/metal-stack/metal-lib/pkg/testcommon"
 )
 
 func Test_ensureContainerdRegistries(t *testing.T) {
@@ -16,17 +15,16 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 		mirrors []apimetal.RegistryMirror
 		configs []extensionsv1alpha1.RegistryConfig
 		want    []extensionsv1alpha1.RegistryConfig
-		wantErr error
 	}{
 		{
 			name:    "maintain existing config",
 			mirrors: nil,
 			configs: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "registry-b",
+					Upstream: "eu.gcr.io",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
-							URL:          "eu.gcr.io",
+							URL:          "https://registry-b",
 							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
 						},
 					},
@@ -34,10 +32,10 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			},
 			want: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "registry-b",
+					Upstream: "eu.gcr.io",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
-							URL:          "eu.gcr.io",
+							URL:          "https://registry-b",
 							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
 						},
 					},
@@ -58,10 +56,10 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			configs: nil,
 			want: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "registry-a",
+					Upstream: "quay.io",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
-							URL:          "quay.io",
+							URL:          "https://registry-a",
 							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability, extensionsv1alpha1.ResolveCapability},
 						},
 					},
@@ -74,7 +72,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			mirrors: []apimetal.RegistryMirror{
 				{
 					Name:     "test registry",
-					Endpoint: "https://registry-a",
+					Endpoint: "https://registry-b",
 					IP:       "1.1.1.1",
 					Port:     443,
 					MirrorOf: []string{"quay.io"},
@@ -82,44 +80,26 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			},
 			configs: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "registry-a",
+					Upstream: "quay.io",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
-							URL:          "old.quay.io",
+							URL:          "https://registry-a",
 							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability, extensionsv1alpha1.ResolveCapability},
 						},
 					},
 					ReadinessProbe: pointer.Pointer(false),
-				},
-				{
-					Upstream: "registry-b",
-					Hosts: []extensionsv1alpha1.RegistryHost{
-						{
-							URL:          "eu.gcr.io",
-							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
-						},
-					},
 				},
 			},
 			want: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "registry-a",
+					Upstream: "quay.io",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
-							URL:          "quay.io",
+							URL:          "https://registry-b",
 							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability, extensionsv1alpha1.ResolveCapability},
 						},
 					},
 					ReadinessProbe: pointer.Pointer(false),
-				},
-				{
-					Upstream: "registry-b",
-					Hosts: []extensionsv1alpha1.RegistryHost{
-						{
-							URL:          "eu.gcr.io",
-							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
-						},
-					},
 				},
 			},
 		},
@@ -136,10 +116,10 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			},
 			configs: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "registry-b",
+					Upstream: "eu.gcr.io",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
-							URL:          "eu.gcr.io",
+							URL:          "https://registry-a",
 							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
 						},
 					},
@@ -147,10 +127,10 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			},
 			want: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "registry-b",
+					Upstream: "quay.io",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
-							URL:          "eu.gcr.io",
+							URL:          "https://registry-a",
 							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
 						},
 					},
@@ -170,11 +150,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ensureContainerdRegistries(tt.mirrors, tt.configs)
-			if diff := cmp.Diff(err, tt.wantErr, testcommon.ErrorStringComparer()); diff != "" {
-				t.Errorf("error diff = %s", diff)
-			}
-
+			got := ensureContainerdRegistries(tt.mirrors, tt.configs)
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("diff = %s", diff)
 			}

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -123,23 +123,25 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
 						},
 					},
+					ReadinessProbe: pointer.Pointer(false),
 				},
 			},
 			want: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "quay.io",
+					Upstream: "eu.gcr.io",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "https://registry-a",
 							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability},
 						},
 					},
+					ReadinessProbe: pointer.Pointer(false),
 				},
 				{
-					Upstream: "registry-a",
+					Upstream: "quay.io",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
-							URL:          "quay.io",
+							URL:          "https://registry-a",
 							Capabilities: []extensionsv1alpha1.RegistryCapability{extensionsv1alpha1.PullCapability, extensionsv1alpha1.ResolveCapability},
 						},
 					},

--- a/pkg/webhook/controlplane/ensurer_test.go
+++ b/pkg/webhook/controlplane/ensurer_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	apimetal "github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/metal"
 	"github.com/metal-stack/metal-lib/pkg/pointer"
+	"github.com/metal-stack/metal-lib/pkg/testcommon"
 )
 
 func Test_ensureContainerdRegistries(t *testing.T) {
@@ -15,13 +16,14 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 		mirrors []apimetal.RegistryMirror
 		configs []extensionsv1alpha1.RegistryConfig
 		want    []extensionsv1alpha1.RegistryConfig
+		wantErr error
 	}{
 		{
 			name:    "maintain existing config",
 			mirrors: nil,
 			configs: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "https://registry-b",
+					Upstream: "registry-b",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "eu.gcr.io",
@@ -32,7 +34,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			},
 			want: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "https://registry-b",
+					Upstream: "registry-b",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "eu.gcr.io",
@@ -56,7 +58,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			configs: nil,
 			want: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "https://registry-a",
+					Upstream: "registry-a",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "quay.io",
@@ -80,7 +82,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			},
 			configs: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "https://registry-a",
+					Upstream: "registry-a",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "old.quay.io",
@@ -90,7 +92,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 					ReadinessProbe: pointer.Pointer(false),
 				},
 				{
-					Upstream: "https://registry-b",
+					Upstream: "registry-b",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "eu.gcr.io",
@@ -101,7 +103,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			},
 			want: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "https://registry-a",
+					Upstream: "registry-a",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "quay.io",
@@ -111,7 +113,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 					ReadinessProbe: pointer.Pointer(false),
 				},
 				{
-					Upstream: "https://registry-b",
+					Upstream: "registry-b",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "eu.gcr.io",
@@ -134,7 +136,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			},
 			configs: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "https://registry-b",
+					Upstream: "registry-b",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "eu.gcr.io",
@@ -145,7 +147,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 			},
 			want: []extensionsv1alpha1.RegistryConfig{
 				{
-					Upstream: "https://registry-b",
+					Upstream: "registry-b",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "eu.gcr.io",
@@ -154,7 +156,7 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 					},
 				},
 				{
-					Upstream: "https://registry-a",
+					Upstream: "registry-a",
 					Hosts: []extensionsv1alpha1.RegistryHost{
 						{
 							URL:          "quay.io",
@@ -168,7 +170,11 @@ func Test_ensureContainerdRegistries(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := ensureContainerdRegistries(tt.mirrors, tt.configs)
+			got, err := ensureContainerdRegistries(tt.mirrors, tt.configs)
+			if diff := cmp.Diff(err, tt.wantErr, testcommon.ErrorStringComparer()); diff != "" {
+				t.Errorf("error diff = %s", diff)
+			}
+
 			if diff := cmp.Diff(got, tt.want); diff != "" {
 				t.Errorf("diff = %s", diff)
 			}


### PR DESCRIPTION
## Description

As the interface is now provided by Gardener it's possible to configure containerd directly through the OSC. This PR requires the removal of the containerd registry configuration from the os-metal-extension.

Advantage of this is that:

1. containerd configuration is managed by Gardener
2. Compatibility with outher extensions like registry cache

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
