### PR TITLE
Retain DNS and NTP additional files if they were present before.

### DIFF
--- a/pkg/webhook/controlplane/add.go
+++ b/pkg/webhook/controlplane/add.go
@@ -219,16 +219,17 @@ func (m *mutator) mutateOperatingSystemConfig(ctx context.Context, gctx gcontext
 				return f.Path == path
 			}); idx >= 0 {
 				osc.Spec.Files = ensureFile(osc.Spec.Files, oldOSC.Status.ExtensionFiles[idx])
-				continue
-			}
-
-			// after this was moved into spec.files we need to re-assure its presence
-			if idx := slices.IndexFunc(oldOSC.Spec.Files, func(f extensionsv1alpha1.File) bool {
+			} else if idx := slices.IndexFunc(oldOSC.Spec.Files, func(f extensionsv1alpha1.File) bool {
 				return f.Path == path
 			}); idx >= 0 {
+				// after this was moved into spec.files we need to re-assure its presence
 				osc.Spec.Files = ensureFile(osc.Spec.Files, oldOSC.Spec.Files[idx])
-				continue
 			}
+
+			// ensure no duplicates in status and spec
+			osc.Status.ExtensionFiles = slices.DeleteFunc(osc.Status.ExtensionFiles, func(f extensionsv1alpha1.File) bool {
+				return f.Path == path
+			})
 		}
 	}
 

--- a/pkg/webhook/controlplane/add.go
+++ b/pkg/webhook/controlplane/add.go
@@ -104,7 +104,9 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 	case *extensionsv1alpha1.OperatingSystemConfig:
 		extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
 
-		err := m.mutateOperatingSystemConfig(ctx, gctx, x, old.(*extensionsv1alpha1.OperatingSystemConfig))
+		o, _ := old.(*extensionsv1alpha1.OperatingSystemConfig)
+
+		err := m.mutateOperatingSystemConfig(ctx, gctx, x, o)
 		if err != nil {
 			return err
 		}

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -2,7 +2,6 @@ package controlplane
 
 import (
 	"context"
-	"slices"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/coreos/go-systemd/v22/unit"
@@ -216,28 +215,6 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 	}
 
 	var files []extensionsv1alpha1.File
-
-	if old != nil {
-		// this is required for backwards-compatibility before we started to create worker machines with DNS and NTP configuration through metal-stack
-		// otherwise existing machines would lose connectivity because the GNA cleans up these file definitions
-		// references https://github.com/metal-stack/gardener-extension-provider-metal/issues/433
-		//
-		// can potentially be cleaned up as soon as there are no worker nodes of isolated clusters anymore that were created without dns and ntp configuration
-		// ideally a point in time should be defined when we add the dns and ntp to the worker hashes to enforce the setting
-		for _, path := range []string{
-			"/etc/systemd/resolved.conf.d/dns.conf",
-			"/etc/resolv.conf",
-			"/etc/systemd/timesyncd.conf",
-		} {
-			if idx := slices.IndexFunc(*old, func(f extensionsv1alpha1.File) bool {
-				return f.Path == path
-			}); idx >= 0 {
-				files = append(files, (*old)[idx])
-			}
-		}
-
-	}
-
 	for _, f := range *new {
 		if f.Path == v1beta1constants.OperatingSystemConfigFilePathKubeletConfig {
 			// for cis benchmark this needs to be 600

--- a/pkg/webhook/controlplane/ensurer.go
+++ b/pkg/webhook/controlplane/ensurer.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"context"
+	"slices"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/coreos/go-systemd/v22/unit"
@@ -215,6 +216,28 @@ func (e *ensurer) EnsureAdditionalFiles(ctx context.Context, gctx gcontext.Garde
 	}
 
 	var files []extensionsv1alpha1.File
+
+	if old != nil {
+		// this is required for backwards-compatibility before we started to create worker machines with DNS and NTP configuration through metal-stack
+		// otherwise existing machines would lose connectivity because the GNA cleans up these file definitions
+		// references https://github.com/metal-stack/gardener-extension-provider-metal/issues/433
+		//
+		// can potentially be cleaned up as soon as there are no worker nodes of isolated clusters anymore that were created without dns and ntp configuration
+		// ideally a point in time should be defined when we add the dns and ntp to the worker hashes to enforce the setting
+		for _, path := range []string{
+			"/etc/systemd/resolved.conf.d/dns.conf",
+			"/etc/resolv.conf",
+			"/etc/systemd/timesyncd.conf",
+		} {
+			if idx := slices.IndexFunc(*old, func(f extensionsv1alpha1.File) bool {
+				return f.Path == path
+			}); idx >= 0 {
+				files = append(files, (*old)[idx])
+			}
+		}
+
+	}
+
 	for _, f := range *new {
 		if f.Path == v1beta1constants.OperatingSystemConfigFilePathKubeletConfig {
 			// for cis benchmark this needs to be 600


### PR DESCRIPTION
## Description

By removing the DNS and NTP additional files and moving this to the machine creation through metal-api we break existing isolated clusters because the GNA cleans up the configuration on existing nodes. We have to retain these files until worker nodes of all isolated were rolled.

References https://github.com/metal-stack/gardener-extension-provider-metal/issues/433.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
