### PR TITLE
Standardize the storage configuration for ETCD main and events by using the same storage class

### DIFF
--- a/pkg/webhook/seedprovider/ensurer.go
+++ b/pkg/webhook/seedprovider/ensurer.go
@@ -8,12 +8,13 @@ import (
 	druidcorev1alpha1 "github.com/gardener/etcd-druid/api/core/v1alpha1"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 	"github.com/go-logr/logr"
-	"github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/config"
-	"github.com/metal-stack/metal-lib/pkg/pointer"
 	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/metal-stack/gardener-extension-provider-metal/pkg/apis/config"
+	"github.com/metal-stack/metal-lib/pkg/pointer"
 
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 
@@ -44,7 +45,7 @@ func (e *ensurer) EnsureETCD(ctx context.Context, gctx gcontext.GardenContext, n
 		return nil
 	}
 
-	if new.Name == v1beta1constants.ETCDMain {
+	if new.Name == v1beta1constants.ETCDMain || new.Name == v1beta1constants.ETCDEvents {
 		if old == nil {
 			// capacity and storage class can only be set on initial deployment
 			// after that the stateful set prevents the update.
@@ -61,7 +62,9 @@ func (e *ensurer) EnsureETCD(ctx context.Context, gctx gcontext.GardenContext, n
 			new.Spec.StorageCapacity = old.Spec.StorageCapacity
 			new.Spec.StorageClass = old.Spec.StorageClass
 		}
+	}
 
+	if new.Name == v1beta1constants.ETCDMain {
 		if e.c.Backup.DeltaSnapshotPeriod != nil {
 			d, err := time.ParseDuration(*e.c.Backup.DeltaSnapshotPeriod)
 			if err != nil {


### PR DESCRIPTION
## Description

It is surprising that it possible to use for example `csi-driver-lvm` for the ETCD main but still use network attached storage for ETCD events.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
