### PR TITLE
Fix metallb webhook

### DIFF
--- a/charts/internal/shoot-control-plane/templates/metallb-crds.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb-crds.yaml
@@ -339,7 +339,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: metallb-webhook-service
+          name: webhook-service
           namespace: metallb-system
           path: /convert
       conversionReviewVersions:

--- a/charts/internal/shoot-control-plane/templates/metallb-crds.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb-crds.yaml
@@ -340,7 +340,7 @@ spec:
       clientConfig:
         service:
           name: metallb-webhook-service
-          namespace: {{ .Release.Namespace }}
+          namespace: metallb-system
           path: /convert
       conversionReviewVersions:
         - v1beta1

--- a/charts/internal/shoot-control-plane/templates/metallb-crds.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb-crds.yaml
@@ -339,7 +339,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: webhook-service
+          name: metallb-webhook-service
           namespace: metallb-system
           path: /convert
       conversionReviewVersions:

--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -434,6 +434,18 @@ data:
     announcedInterfacesToExclude: ["^docker.*", "^cbr.*", "^dummy.*", "^virbr.*", "^lxcbr.*", "^veth.*", "^lo$", "^cali.*", "^tunl.*", "^flannel.*", "^kube-ipvs.*", "^cni.*", "^nodelocaldns.*"]
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  name: webhook-server-cert
+  namespace: metallb-system
+type: Opaque
+data:
+  ca.crt: {{ .Values.metallb.webhook-server.ca }}
+  ca.key: {{ .Values.metallb.webhook-server.caKey }}
+  tls.crt: {{ .Values.metallb.webhook-server.cert }}
+  tls.key: {{ .Values.metallb.webhook-server.key }}
+---
+apiVersion: v1
 kind: Service
 metadata:
   name: metallb-webhook-service
@@ -575,6 +587,9 @@ spec:
       annotations:
         prometheus.io/port: "7472"
         prometheus.io/scrape: "true"
+{{- if .Values.metallb.podAnnotations }}
+{{ toYaml .Values.metallb.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         app: metallb
         component: controller
@@ -586,6 +601,7 @@ spec:
         - --log-level=info
         - --tls-min-version=VersionTLS12
         - --webhook-secret=webhook-server-cert
+        - --disable-cert-rotation=true
         env:
         - name: METALLB_ML_SECRET_NAME
           value: memberlist

--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -434,12 +434,6 @@ data:
     announcedInterfacesToExclude: ["^docker.*", "^cbr.*", "^dummy.*", "^virbr.*", "^lxcbr.*", "^veth.*", "^lo$", "^cali.*", "^tunl.*", "^flannel.*", "^kube-ipvs.*", "^cni.*", "^nodelocaldns.*"]
 ---
 apiVersion: v1
-kind: Secret
-metadata:
-  name: webhook-server-cert
-  namespace: metallb-system
----
-apiVersion: v1
 kind: Service
 metadata:
   name: metallb-webhook-service

--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -440,10 +440,10 @@ metadata:
   namespace: metallb-system
 type: Opaque
 data:
-  ca.crt: {{ .Values.metallb.webhook-server.ca }}
-  ca.key: {{ .Values.metallb.webhook-server.caKey }}
-  tls.crt: {{ .Values.metallb.webhook-server.cert }}
-  tls.key: {{ .Values.metallb.webhook-server.key }}
+  ca.crt: {{ .Values.metallb.webhook.ca }}
+  ca.key: {{ .Values.metallb.webhook.caKey }}
+  tls.crt: {{ .Values.metallb.webhook.cert }}
+  tls.key: {{ .Values.metallb.webhook.key }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/internal/shoot-control-plane/templates/metallb.yaml
+++ b/charts/internal/shoot-control-plane/templates/metallb.yaml
@@ -442,7 +442,7 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: webhook-service
+  name: metallb-webhook-service
   namespace: metallb-system
 spec:
   ports:
@@ -591,7 +591,7 @@ spec:
         - --port=7472
         - --log-level=info
         - --tls-min-version=VersionTLS12
-        - --webhook-mode=disabled
+        - --webhook-secret=webhook-server-cert
         env:
         - name: METALLB_ML_SECRET_NAME
           value: memberlist

--- a/charts/internal/shoot-control-plane/values.yaml
+++ b/charts/internal/shoot-control-plane/values.yaml
@@ -22,7 +22,7 @@ cilium:
 metallb:
   enabled: true
   podAnnotations: {}
-  webhook-server:
+  webhook:
     ca:
     caKey:
     cert:

--- a/charts/internal/shoot-control-plane/values.yaml
+++ b/charts/internal/shoot-control-plane/values.yaml
@@ -21,6 +21,12 @@ cilium:
 
 metallb:
   enabled: true
+  podAnnotations: {}
+  webhook-server:
+    ca:
+    caKey:
+    cert:
+    key:
 
 nodeInit:
   enabled: true

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -183,7 +183,7 @@ var cpShootChart = &chart.Chart{
 		{Type: &rbacv1.RoleBinding{}, Name: "health-monitoring"},
 		{Type: &corev1.ConfigMap{}, Name: "metallb-excludel2"},
 		{Type: &corev1.Secret{}, Name: "webhook-server-cert"},
-		{Type: &corev1.Service{}, Name: "webhook-service"},
+		{Type: &corev1.Service{}, Name: "metallb-webhook-service"},
 		{Type: &appsv1.DaemonSet{}, Name: "speaker"},
 		{Type: &appsv1.Deployment{}, Name: "controller"},
 

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -645,7 +645,7 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(ctx context.Context, c
 	droptailerClient, clientOK := secretsReader.Get(metal.DroptailerClientSecretName)
 	if serverOK && clientOK {
 		values["droptailer"] = map[string]any{
-			"podAnnotations": map[string]interface{}{
+			"podAnnotations": map[string]any{
 				"checksum/secret-droptailer-server": checksums[metal.DroptailerServerSecretName],
 				"checksum/secret-droptailer-client": checksums[metal.DroptailerClientSecretName],
 			},

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -523,12 +523,11 @@ func (vp *valuesProvider) getControlPlaneShootChartValues(ctx context.Context, c
 		}
 	)
 
-	metallbCert, ok := secretsReader.Get(metal.DroptailerServerSecretName)
-	if ok {
+	if metallbCert, ok := secretsReader.Get(metal.MetalLbWebhookSecretName); ok {
 		metallbValues["podAnnotations"] = map[string]any{
 			"checksum/secret-metallb-webhook-server": checksums[metal.MetalLbWebhookSecretName],
 		}
-		metallbValues["webhook-server"] = map[string]any{
+		metallbValues["webhook"] = map[string]any{
 			"ca":    metallbCert.Data["ca.crt"],
 			"caKey": metallbCert.Data["ca.key"],
 			"cert":  metallbCert.Data["tls.crt"],

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -182,7 +182,6 @@ var cpShootChart = &chart.Chart{
 		{Type: &rbacv1.RoleBinding{}, Name: "controller"},
 		{Type: &rbacv1.RoleBinding{}, Name: "health-monitoring"},
 		{Type: &corev1.ConfigMap{}, Name: "metallb-excludel2"},
-		{Type: &corev1.Secret{}, Name: "webhook-server-cert"},
 		{Type: &corev1.Service{}, Name: "metallb-webhook-service"},
 		{Type: &appsv1.DaemonSet{}, Name: "speaker"},
 		{Type: &appsv1.Deployment{}, Name: "controller"},

--- a/pkg/metal/types.go
+++ b/pkg/metal/types.go
@@ -43,6 +43,8 @@ const (
 	DroptailerClientSecretName = "droptailer-client" // nolint:gosec
 	// DroptailerServerSecretName is the name of the secret containing the certificates for the droptailer server.
 	DroptailerServerSecretName = "droptailer-server" // nolint:gosec
+	// MetalLbWebhookSecretName is the name of the secret containing the certificates for the metallb webhook server.
+	MetalLbWebhookSecretName = "metallb-webhook-cert" // nolint:gosec
 	// CloudControllerManagerDeploymentName is the name of the deployment for the cloud controller manager.
 	CloudControllerManagerDeploymentName = "cloud-controller-manager"
 	// CloudControllerManagerServerName is the name of the secret containing the certificates for the cloud controller manager server.


### PR DESCRIPTION
## Description

At the moment, the kube-apiserver logs are full with errors:

```
kube-apiserver-7466789877-lvn5x kube-apiserver E0917 07:44:32.904067       1 cacher.go:478] cacher (bgppeers.metallb.io): unexpected ListAndWatch error: failed to list metallb.io/v1beta1, Kind=BGPPeer: conversion webhook for metallb.io/v1beta2, Kind=BGPPeer failed: Post "https://metallb-webhook-service.kube-system.svc:443/convert?timeout=30s": service "metallb-webhook-service" not found; reinitializing...
```

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
