### PR TITLE
restrict ccm rbac for nodes

### DIFF
--- a/charts/internal/shoot-control-plane/templates/rbac-node-controller.yaml
+++ b/charts/internal/shoot-control-plane/templates/rbac-node-controller.yaml
@@ -61,7 +61,10 @@ rules:
   resources:
     - nodes
   verbs:
-    - "*"
+    - get
+    - list
+    - watch
+    - update
 - apiGroups:
     - ""
   resources:


### PR DESCRIPTION
## Description

From the CIS-Benchmark CIS-Version 1.32 results:
> 5.1.3 - Minimize wildcard use in Roles and ClusterRoles (cloud-controller-manager)
