### PR TITLE
[GEP-28] Use technicalID from `Cluster` instead of `Worker.Namespace`

### DIFF
--- a/pkg/controller/worker/machines.go
+++ b/pkg/controller/worker/machines.go
@@ -147,10 +147,10 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 
 		var (
 			metalClusterIDTag      = fmt.Sprintf("%s=%s", tag.ClusterID, w.cluster.Shoot.GetUID())
-			metalClusterNameTag    = fmt.Sprintf("%s=%s", tag.ClusterName, w.worker.Namespace)
+			metalClusterNameTag    = fmt.Sprintf("%s=%s", tag.ClusterName, w.cluster.Shoot.Status.TechnicalID)
 			metalClusterProjectTag = fmt.Sprintf("%s=%s", tag.ClusterProject, w.additionalData.infrastructureConfig.ProjectID)
 
-			kubernetesClusterTag        = fmt.Sprintf("kubernetes.io/cluster=%s", w.worker.Namespace)
+			kubernetesClusterTag        = fmt.Sprintf("kubernetes.io/cluster=%s", w.cluster.Shoot.Status.TechnicalID)
 			kubernetesRoleTag           = "kubernetes.io/role=node"
 			kubernetesInstanceTypeTag   = fmt.Sprintf("node.kubernetes.io/instance-type=%s", pool.MachineType)
 			kubernetesTopologyRegionTag = fmt.Sprintf("topology.kubernetes.io/region=%s", w.worker.Spec.Region)
@@ -220,7 +220,7 @@ func (w *workerDelegate) generateMachineConfig(ctx context.Context) error {
 		}
 
 		var (
-			deploymentName = fmt.Sprintf("%s-%s", w.worker.Namespace, pool.Name)
+			deploymentName = fmt.Sprintf("%s-%s", w.cluster.Shoot.Status.TechnicalID, pool.Name)
 		)
 
 		override, ok, err := keepHash(deploymentName)


### PR DESCRIPTION
## Description

To support self-hosted shoots with managed infrastructure, the `Worker` controller/delegate needs to use the technical ID from `Cluster.shoot.status.technicalID` for prefixing the names of machine-related objects. The `Worker` namespace is `kube-system` for self-hosted shoots.
This PR is similar to [gardener/gardener@`22f4295` (#13485)](https://github.com/gardener/gardener/pull/13485/commits/22f429593ba87fb08c3a37fb0ce3c1da914c0f21).

Part of https://github.com/gardener/gardener/pull/13485

While this PR adapts all relevant places in the existing controllers, support for bootstrapping self-hosted shoots with managed infrastructure will still require a `Bastion` controller implementation.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
