### PR TITLE
Add endpointslices to firewall-controller-manager clusterrole

### DIFF
--- a/charts/gardener-extension-provider-metal/templates/rbac.yaml
+++ b/charts/gardener-extension-provider-metal/templates/rbac.yaml
@@ -63,6 +63,7 @@ rules:
   - admissionregistration.k8s.io
   - apiextensions.k8s.io
   - networking.k8s.io
+  - discovery.k8s.io
   resources:
   - namespaces
   - namespaces/finalizers
@@ -70,6 +71,7 @@ rules:
   - secrets
   - configmaps
   - endpoints
+  - endpointslices
   - deployments
   - deployments/scale
   - services

--- a/charts/internal/shoot-control-plane/templates/rbac-firewall-controller-manager.yaml
+++ b/charts/internal/shoot-control-plane/templates/rbac-firewall-controller-manager.yaml
@@ -95,6 +95,16 @@ rules:
   - list
   - watch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - create
+  - update
+  - list
+  - watch
+- apiGroups:
   - networking.k8s.io
   resources:
   - networkpolicies


### PR DESCRIPTION
## Description
Add endpointslices to firewall-controller-manager clusterrole

required by: https://github.com/metal-stack/firewall-controller-manager/pull/84