### PR TITLE
Adjustments to new metal-ccm health probe.

### DIFF
--- a/charts/internal/control-plane/templates/cloud-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/cloud-controller-manager.yaml
@@ -129,6 +129,15 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 60
           timeoutSeconds: 15
+        startupProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: {{ include "cloud-controller-manager.port" . }}
+          successThreshold: 1
+          initialDelaySeconds: 15
+          periodSeconds: 5
+          timeoutSeconds: 5
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         {{- if .Values.cloudControllerManager.resources }}

--- a/charts/internal/control-plane/templates/cloud-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/cloud-controller-manager.yaml
@@ -113,7 +113,7 @@ spec:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: {{ include "cloud-controller-manager.port" . }}
+            port: ccm-secure
           successThreshold: 1
           failureThreshold: 6
           initialDelaySeconds: 15

--- a/charts/internal/control-plane/templates/cloud-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/cloud-controller-manager.yaml
@@ -123,7 +123,7 @@ spec:
           httpGet:
             path: /healthz
             scheme: HTTPS
-            port: {{ include "cloud-controller-manager.port" . }}
+            port: ccm-secure
           successThreshold: 1
           initialDelaySeconds: 15
           periodSeconds: 5

--- a/charts/internal/control-plane/templates/cloud-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/cloud-controller-manager.yaml
@@ -115,7 +115,7 @@ spec:
             scheme: HTTPS
             port: ccm-secure
           successThreshold: 1
-          failureThreshold: 6
+          failureThreshold: 15
           initialDelaySeconds: 15
           periodSeconds: 60
           timeoutSeconds: 15

--- a/charts/internal/control-plane/templates/cloud-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/cloud-controller-manager.yaml
@@ -66,8 +66,6 @@ spec:
         imagePullPolicy: {{ .Values.imagePullPolicy }}
         command:
         - ./metal-cloud-controller-manager
-        - --cluster-cidr={{ .Values.cloudControllerManager.podNetwork }}
-        - --cluster-name={{ .Values.cloudControllerManager.clusterName }}
         - --concurrent-service-syncs=10
         {{- include "cloud-controller-manager.featureGates" . | trimSuffix "," | indent 8 }}
         - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
@@ -107,15 +105,29 @@ spec:
             value: {{ .Values.cloudControllerManager.sshPublicKey | quote }}
           - name: LOADBALANCER
             value: {{ .Values.cloudControllerManager.loadBalancer }}
+        ports:
+          - name: server
+            containerPort: {{ include "cloud-controller-manager.port" . }}
+            protocol: TCP
         livenessProbe:
           httpGet:
             path: /healthz
             scheme: HTTPS
             port: {{ include "cloud-controller-manager.port" . }}
           successThreshold: 1
-          failureThreshold: 2
+          failureThreshold: 6
           initialDelaySeconds: 15
-          periodSeconds: 10
+          periodSeconds: 60
+          timeoutSeconds: 15
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            scheme: HTTPS
+            port: {{ include "cloud-controller-manager.port" . }}
+          successThreshold: 1
+          failureThreshold: 6
+          initialDelaySeconds: 15
+          periodSeconds: 60
           timeoutSeconds: 15
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File

--- a/charts/internal/control-plane/templates/cloud-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/cloud-controller-manager.yaml
@@ -119,16 +119,6 @@ spec:
           initialDelaySeconds: 15
           periodSeconds: 60
           timeoutSeconds: 15
-        readinessProbe:
-          httpGet:
-            path: /healthz
-            scheme: HTTPS
-            port: {{ include "cloud-controller-manager.port" . }}
-          successThreshold: 1
-          failureThreshold: 6
-          initialDelaySeconds: 15
-          periodSeconds: 60
-          timeoutSeconds: 15
         startupProbe:
           httpGet:
             path: /healthz

--- a/charts/internal/control-plane/templates/cloud-controller-manager.yaml
+++ b/charts/internal/control-plane/templates/cloud-controller-manager.yaml
@@ -106,7 +106,7 @@ spec:
           - name: LOADBALANCER
             value: {{ .Values.cloudControllerManager.loadBalancer }}
         ports:
-          - name: server
+          - name: ccm-secure
             containerPort: {{ include "cloud-controller-manager.port" . }}
             protocol: TCP
         livenessProbe:

--- a/pkg/controller/controlplane/valuesprovider.go
+++ b/pkg/controller/controlplane/valuesprovider.go
@@ -792,7 +792,6 @@ func getCCMChartValues(
 			"clusterID":              cluster.Shoot.UID,
 			"partitionID":            infrastructureConfig.PartitionID,
 			"networkID":              *privateNetwork.ID,
-			"podNetwork":             extensionscontroller.GetPodNetwork(cluster),
 			"defaultExternalNetwork": defaultExternalNetwork,
 			"additionalNetworks":     strings.Join(infrastructureConfig.Firewall.Networks, ","),
 			"loadBalancer":           loadBalancer,


### PR DESCRIPTION
## Description

As now the metal-api gets called in the probe, we can increase the period a bit to match prior behavior of the housekeeper.

I use a startup probe to fasten up rolling updates, I dropped the readiness probe because there is no real readyz endpoint and it doubles the amount of requests to the metal-api for no real reason, it does not receive mention-able traffic anyway.

Also added a bit of cleanup of old flags.

```plain
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:25:33.944177       1 metallb_config.go:85] bgppeer: updated
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:25:33.945465       1 loadbalancer.go:308] load balancer config updated successfully
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:25:54.397922       1 health.go:40] external health check: metal-api is healthy
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:26:33.896994       1 tags.go:31] start syncing machine tags to node labels
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:26:33.943917       1 metallb_config.go:85] bgppeer: updated
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:26:33.945168       1 loadbalancer.go:308] load balancer config updated successfully
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:26:54.398523       1 health.go:40] external health check: metal-api is healthy
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:27:33.897260       1 tags.go:31] start syncing machine tags to node labels
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:27:33.943959       1 metallb_config.go:85] bgppeer: updated
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:27:33.945400       1 loadbalancer.go:308] load balancer config updated successfully
cloud-controller-manager-65854775dc-sqf4h cloud-controller-manager I0521 11:27:54.398573       1 health.go:40] external health check: metal-api is healthy
```

#### Used AI-Tools ✨

<!-- If not used, delete the next section.

For commits with substantial parts that were generated by AI, please also mark the commits with the Generated-By: [tool name] label as described in our contribution guideline: https://metal-stack.io/community/contribution-guideline/#usage-of-generative-ai-tools.
 -->

- None used for generation

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
