### PR TITLE
fix: change calico bpfConnectTimeLoadBalancing from default "TCP" to "Enabled", to also allow udp-connection from host to kubernetes services

### DIFF
--- a/charts/images.go
+++ b/charts/images.go
@@ -3,5 +3,6 @@ package charts
 import _ "embed"
 
 // ImagesYAML contains the content of the images.yaml file
+//
 //go:embed images.yaml
 var ImagesYAML string

--- a/pkg/webhook/shoot/mutator.go
+++ b/pkg/webhook/shoot/mutator.go
@@ -120,6 +120,11 @@ func (m *mutator) mutateCalicoNode(_ context.Context, ds *appsv1.DaemonSet) erro
 			Name:  "FELIX_MTUIFACEPATTERN",
 			Value: "lan",
 		})
+
+		c.Env = extensionswebhook.EnsureEnvVarWithName(c.Env, corev1.EnvVar{
+			Name:  "FELIX_BPFCONNECTTIMELOADBALANCING",
+			Value: "Enabled",
+		})
 	}
 
 	return nil


### PR DESCRIPTION
## Description

When running Calico in eBPF mode, UDP connections (e.g. to the kube-dns service) timeout if **all** of the following conditions are met:
1. Pod uses `hostNetwork: true` and `dnsPolicy: ClusterFirstWithHostNet`.
2. Traffic uses UDP (e.g., standard DNS requests).
3. Target is a cluster-internal Service (e.g., CoreDNS ClusterIP).
4. No backend pod for the target Service is running on the local node (e.g., all CoreDNS pods are running on different nodes).

### Root Cause
By default, Calico `bpfConnectTimeLoadBalancing (required for the host to be able to reach Kubernetes services)` is set to `TCP`. 

```
  bpfConnectTimeLoadBalancing:
    description: |-
      BPFConnectTimeLoadBalancing when in BPF mode, controls whether Felix installs the connect-time load
      balancer. The connect-time load balancer is required for the host to be able to reach Kubernetes services
      and it improves the performance of pod-to-service connections.When set to TCP, connect time load balancing
      is available only for services with TCP ports. [Default: TCP]

```

This PR sets `bpfConnectTimeLoadBalancing` to `Enabled`, which then also includes UDP.

- [x] tested in test env:

```
$ k exec -it busybox-2 -- sh
~ $ nslookup -type=a spiegel.de
;; connection timed out; no servers could be reached

# cloudctl cluster reconcile ...

~ $ nslookup -type=a spiegel.de
Server:         10.244.64.10
Address:        10.244.64.10:53

Non-authoritative answer:
Name:   spiegel.de
Address: 128.65.223.150

```
